### PR TITLE
[QOLOE-198] Handling js error when breadcrumb component does not exist.

### DIFF
--- a/src/components/bs5/breadcrumbs/breadcrumb.functions.js
+++ b/src/components/bs5/breadcrumbs/breadcrumb.functions.js
@@ -1,37 +1,60 @@
 /**
+ * Initialise the Breadcrumb component.
+ * Shorten long breadcrumbs when required.
+ *
+ * @memberof module:Breadcrumb
+ *
+ * @returns {void} Returns early when breadcrumb does not exist or its length is within set maxLength. 
+ */
+export function initBreadcrumb() {
+  // Set the standard breadcrumb length.
+  const maxLength = 4;
+  // Get the breadcrumb DOM element.
+  const breadcrumbList = document.querySelector('.breadcrumb').querySelectorAll('.breadcrumb-item');
+  // Return when breadcrumb does not exist.
+  if (!breadcrumbList || !breadcrumbList.length) {
+    return;
+  }
+  // Shorten breadcrumb.
+  breadcrumbShorten(breadcrumbList, maxLength);
+}
+
+/**
  * Shorten long breadcrumb lists
  *
  * @memberof module:Breadcrumb
  *
- * @param  {Object}  event - The event that triggered this function.
- * @returns {void}
+ * @param  {Element} breadcrumbList - Breadcrumb DOM element.
+ * @param  {number} maxLength - Standard maximum length for breadcrumb.
+ * @returns {void} Returns early when breadcrumb does not exist or its length is within set maxLength.
  */
-export function breadcrumbShorten () {
-  let breadcrumbList = document.querySelector('.breadcrumb').querySelectorAll('.breadcrumb-item')
-
-  if (breadcrumbList.length > 4) {
-    breadcrumbList.forEach((crumb, index) => {
-      if (index > 1 && index < breadcrumbList.length - 2) {
-        crumb.classList.add('shortened')
-        crumb.querySelector('a').setAttribute('tabindex',-1)
-      }
-
-      if (index === 1) {
-        let expandCrumb = document.createElement('li'),
-          expandButton = document.createElement('a')
-
-        expandCrumb.classList.add('breadcrumb-item','breadcrumb-toggle')
-
-        expandButton.setAttribute('href', 'javascript:void(0)')
-        expandButton.setAttribute('aria-label', 'Expand the breadcrumbs')
-        expandButton.textContent = '[...]'
-        expandButton.addEventListener('click', breadcrumbExpand)
-
-        expandCrumb.appendChild(expandButton)
-        crumb.after(expandCrumb)
-      }
-    })
+export function breadcrumbShorten(breadcrumbList, maxLength = 4) {
+  // No shortening is required when breadcrumb does not exist or its length is within the maximum range.
+  if (!breadcrumbList || breadcrumbList.length <= maxLength) {
+    return;
   }
+
+  breadcrumbList.forEach((crumb, index) => {
+    if (index > 1 && index < breadcrumbList.length - 2) {
+      crumb.classList.add('shortened')
+      crumb.querySelector('a').setAttribute('tabindex',-1)
+    }
+
+    if (index === 1) {
+      let expandCrumb = document.createElement('li'),
+        expandButton = document.createElement('a')
+
+      expandCrumb.classList.add('breadcrumb-item','breadcrumb-toggle')
+
+      expandButton.setAttribute('href', 'javascript:void(0)')
+      expandButton.setAttribute('aria-label', 'Expand the breadcrumbs')
+      expandButton.textContent = '[...]'
+      expandButton.addEventListener('click', breadcrumbExpand)
+
+      expandCrumb.appendChild(expandButton)
+      crumb.after(expandCrumb)
+    }
+  })
 }
 
 /**
@@ -39,12 +62,17 @@ export function breadcrumbShorten () {
  *
  * @memberof module:Breadcrumb
  *
- * @param  {Object}  event - The event that triggered this function.
- * @returns {void}
+ * @param  {Event} event - The event that triggered this function.
+ * @returns {void} Returns early when the breadcrumb does not exist or is empty.
  */
-export function breadcrumbExpand () {
-  let breadcrumbList = document.querySelector('.breadcrumb').querySelectorAll('.breadcrumb-item')
+export function breadcrumbExpand(event) {
+  const breadcrumbList = event.target.closest('.breadcrumb').querySelectorAll('.breadcrumb-item');
 
+  if (!breadcrumbList || !breadcrumbList.length) {
+    console.log('Breadcrumb does not exist or is empty.');
+    return;
+  }
+  
   breadcrumbList[0].parentElement.classList.add('expanded')
 
   breadcrumbList.forEach((crumb, index) => {

--- a/src/components/bs5/breadcrumbs/breadcrumb.functions.js
+++ b/src/components/bs5/breadcrumbs/breadcrumb.functions.js
@@ -9,8 +9,14 @@
 export function initBreadcrumb() {
   // Set the standard breadcrumb length.
   const maxLength = 4;
+
   // Get the breadcrumb DOM element.
-  const breadcrumbList = document.querySelector('.breadcrumb').querySelectorAll('.breadcrumb-item');
+  const breadcrumb = document.querySelector('.breadcrumb');
+  if (!breadcrumb) {
+    return;
+  }
+  const breadcrumbList = breadcrumb.querySelectorAll('.breadcrumb-item');
+
   // Return when breadcrumb does not exist.
   if (!breadcrumbList || !breadcrumbList.length) {
     return;
@@ -66,10 +72,15 @@ export function breadcrumbShorten(breadcrumbList, maxLength = 4) {
  * @returns {void} Returns early when the breadcrumb does not exist or is empty.
  */
 export function breadcrumbExpand(event) {
-  const breadcrumbList = event.target.closest('.breadcrumb').querySelectorAll('.breadcrumb-item');
+  const breadcrumb = event.target.closest('.breadcrumb');
+  if (!breadcrumb) {
+    console.log('breadcrumbExpand: Breadcrumb does not exist.');
+    return;
+  }
+  const breadcrumbList = breadcrumb.querySelectorAll('.breadcrumb-item');
 
   if (!breadcrumbList || !breadcrumbList.length) {
-    console.log('Breadcrumb does not exist or is empty.');
+    console.log('breadcrumbExpand: Breadcrumb does not exist or is empty.');
     return;
   }
   

--- a/src/main.js
+++ b/src/main.js
@@ -1,7 +1,7 @@
 import { accordionToggleAll, accordionToggleAllButtonState, accordionHashLinks } from "./components/bs5/accordion/accordion.functions";
 import { videoEmbedPlay, videoTranscriptTitle } from "./components/bs5/video/video.functions";
 import { initializeNavbar } from './components/bs5/navbar/navbar.functions';
-import { breadcrumbShorten } from "./components/bs5/breadcrumbs/breadcrumb.functions";
+import { initBreadcrumb } from "./components/bs5/breadcrumbs/breadcrumb.functions";
 import { positionQuickExit, initQuickexit } from './components/bs5/quickexit/quickexit.functions';
 import { toggleSearch, showSuggestions } from './components/bs5/header/header.functions';
 
@@ -62,7 +62,7 @@ window.addEventListener("DOMContentLoaded", () => {
     initializeNavbar();
 
     // Breadcrumb
-    breadcrumbShorten();
+    initBreadcrumb();
 
     // Quick exit
     initQuickexit();


### PR DESCRIPTION
This is a fix for:
breadcrumb shortening function (breadcrumbShorten) is being called on a page regardless whether the component exists, which causing a javascript error on the page.

Changes:
- Added an init function for breadcrumb component 
- Added checking for breadcrumb existence before shortening breadcrumb
- Update function to accept maxLength parameter to allow dynamic breadcrumb length control, when required
- Utilise the event param on breadcrumbExpand event handler to allow more targeted element