### PR TITLE
[QOLOE-259] Fix intermittent error with /dist folder clean up when running npm run dev-storybook

### DIFF
--- a/.esbuild/plugins/qgds-plugin-clean-output-folders.js
+++ b/.esbuild/plugins/qgds-plugin-clean-output-folders.js
@@ -1,30 +1,39 @@
 import fs from "fs";
 import log from "../helpers/logger.js";
 
+/**
+ * Clean the output folders /dist.
+ * Skip cleaning during the initial build or initial watch mode.
+ *
+ * @returns {Object} Object with a name and a setup function.
+ */
 export default function cleanFoldersPlugin() {
+  let isInitialBuild = true;
   return {
     name: "qgds-clean-output-folders",
     setup(build) {
       build.onStart(() => {
-        //Console feedback
-        log("cyan", `\u{1F4C2} Cleaning /dist folders\n\n`);
+        if (!isInitialBuild) {
+          //Console feedback
+          log("cyan", `\u{1F4C2} Cleaning /dist folders\n\n`);
 
-        // Clean the output folders
-        const { outdir, outfile } = build.initialOptions;
+          // Clean the output folders
+          const { outdir, outfile } = build.initialOptions;
 
-        if (outdir && fs.existsSync(outdir)) {
-          fs.rmSync(outdir, { recursive: true });
+          if (outdir && fs.existsSync(outdir)) {
+            fs.rmSync(outdir, { recursive: true });
+          }
+
+          if (outfile && fs.existsSync(outfile)) {
+            fs.rmSync(outfile);
+          }
+
+          // // Clean the docs folder
+          // const docsdir = "./docs/";
+          // if (fs.existsSync(docsdir)) {
+          //   fs.rmSync(docsdir, { recursive: true });
+          // }
         }
-
-        if (outfile && fs.existsSync(outfile)) {
-          fs.rmSync(outfile);
-        }
-
-        // // Clean the docs folder
-        // const docsdir = "./docs/";
-        // if (fs.existsSync(docsdir)) {
-        //   fs.rmSync(docsdir, { recursive: true });
-        // }
       });
     },
   };

--- a/.esbuild/plugins/qgds-plugin-clean-output-folders.js
+++ b/.esbuild/plugins/qgds-plugin-clean-output-folders.js
@@ -34,6 +34,7 @@ export default function cleanFoldersPlugin() {
           //   fs.rmSync(docsdir, { recursive: true });
           // }
         }
+        isInitialBuild = false;
       });
     },
   };


### PR DESCRIPTION
[QOLOE-259]Fix intermittent error with /dist folder clean up when running npm run dev-storybook:
- Update ESBuild clean up plugin to ignore cleaning output folders during the initial build or initial watch mode.
- This Intermittent error was replicated in Theo and Elvi's machines - who have very different specs

Test:
- Tested on both developers machines.
- Tested on a complete clean build - when node_modules and dist folders do not exist
- Tested on existing build - with node_modules and dist folders exist.

[QOLOE-259]: https://ssq-qol.atlassian.net/browse/QOLOE-259?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ