### PR TITLE
[QOLOE-180]Fix Close button on small size modal in Desktop view.

### DIFF
--- a/src/components/bs5/modal/modal.scss
+++ b/src/components/bs5/modal/modal.scss
@@ -55,6 +55,7 @@
         border-radius: var(--#{$prefix}btn-border-radius);
         background-size: 12px;
         padding: 0;
+        flex-shrink: 0;  //Flex, do not shrink this perfectly round button.
 
         &:hover {
             width: var(--#{$prefix}btn-close-width);


### PR DESCRIPTION
The Close button on small size modal is squashed in Desktop view due to css flex auto shrink.
Setting flex-shrink to 0 so the button would not get squashed.


Bug:
![Screenshot 2024-06-12 at 11 18 58 AM](https://github.com/qld-gov-au/qgds-bootstrap5/assets/8241421/527ab3c4-911f-477d-9719-5c7d0e7c788a)


Fixed:
![Screenshot 2024-06-12 at 11 19 31 AM](https://github.com/qld-gov-au/qgds-bootstrap5/assets/8241421/539e2a21-05b5-4bfa-8f14-6fcb43b82218)
