### PR TITLE
QOLOE-125 CICD setup for CDN deployment via Release Binary Repo

### DIFF
--- a/.binary-repo/.github/aws/README.md
+++ b/.binary-repo/.github/aws/README.md
@@ -1,0 +1,57 @@
+## AWS Environment connectivity for cdn deployment.
+
+This iam config is required to allow github Actions to deploy to
+aws for an environment release.
+
+
+```shell
+deploy_stack() {
+  local ENV=$1
+  local STACK_NAME="QGDS-Bootstrap5-$ENV"
+  local S3_BUCKET_NAME="/config/QGDS-Bootstrap5/$ENV/S3BucketName"
+  local S3_BUCKET_PATH="/config/QGDS-Bootstrap5/$ENV/S3BucketPath"
+
+  aws cloudformation deploy \
+    --template-file iam.cfn.yml \
+    --stack-name $STACK_NAME \
+    --capabilities CAPABILITY_IAM \
+    --parameter-overrides \
+      Branch1=main \
+      Branch2=develop \
+      Environment=$ENV \
+      GitHubOIDCProviderARN=/config/GitHubOIDCProviderARN \
+      GitHubOrg=qld-gov-au \
+      RepoName=qgds-Bootstrap5-release \
+      S3BucketName=$S3_BUCKET_NAME \
+      S3BucketPath=$S3_BUCKET_PATH
+}
+
+# Example usage:
+deploy_stack DEV
+deploy_stack TEST
+deploy_stack STAGING
+deploy_stack PROD
+deploy_stack BETA
+```
+
+
+## GitHub Environments
+ 1. Setup one or more enviroments DEV|TEST|etc
+ 2. Add secrets: AWS_IAM_ROLE and S3BUCKET based on what is set in your aws param store configuration
+ 3. Add branch/tag restrictions
+ 4. deploy via github action script cdnAWSDeployment.yml
+
+### Script to create environments
+
+Prerequisites
+Ensure you have the GitHub CLI (gh) installed.
+https://cli.github.com/
+i.e. for mac  ``brew install gh``
+
+Authenticate gh to your GitHub account by running 
+``gh auth login`` and following the prompts.
+
+```shell
+./setup_github_environment.sh qld-gov-au qgds-bootstrap5-release DEV your-s3-bucket-name your-aws-iam-role-arn
+
+```

--- a/.binary-repo/.github/aws/example_cloudfront.cfn.yml
+++ b/.binary-repo/.github/aws/example_cloudfront.cfn.yml
@@ -1,0 +1,141 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: CloudFormation template to create an ACM certificate in us-east-1 and a CloudFront distribution with up to 5 origins and behavior suffixes.
+
+Parameters:
+  DomainName:
+    Type: String
+    Description: The primary domain name for the ACM certificate.
+  SubjectAlternativeNames:
+    Type: CommaDelimitedList
+    Description: Additional domain names for the ACM certificate.
+    Default: ""
+
+  OriginDomain1:
+    Type: String
+    Description: The first origin domain name (S3 bucket or custom domain).
+  OriginDomain2:
+    Type: String
+    Description: The second origin domain name (S3 bucket or custom domain).
+    Default: ""
+  OriginDomain3:
+    Type: String
+    Description: The third origin domain name (S3 bucket or custom domain).
+    Default: ""
+  OriginDomain4:
+    Type: String
+    Description: The fourth origin domain name (S3 bucket or custom domain).
+    Default: ""
+  OriginDomain5:
+    Type: String
+    Description: The fifth origin domain name (S3 bucket or custom domain).
+    Default: ""
+
+  OriginPath1:
+    Type: String
+    Description: The behavior suffix for the first origin.
+    Default: ""
+  OriginPath2:
+    Type: String
+    Description: The behavior suffix for the second origin.
+    Default: ""
+  OriginPath3:
+    Type: String
+    Description: The behavior suffix for the third origin.
+    Default: ""
+  OriginPath4:
+    Type: String
+    Description: The behavior suffix for the fourth origin.
+    Default: ""
+  OriginPath5:
+    Type: String
+    Description: The behavior suffix for the fifth origin.
+    Default: ""
+
+Resources:
+  Certificate:
+    Type: "AWS::CertificateManager::Certificate"
+    Properties:
+      DomainName: !Ref DomainName
+      ValidationMethod: DNS
+      SubjectAlternativeNames: !Ref SubjectAlternativeNames
+      Tags:
+        - Key: Name
+          Value: !Ref DomainName
+
+  CloudFrontDistribution:
+    Type: "AWS::CloudFront::Distribution"
+    Properties:
+      DistributionConfig:
+        Enabled: true
+        DefaultCacheBehavior:
+          TargetOriginId: origin1
+          ViewerProtocolPolicy: redirect-to-https
+          ForwardedValues:
+            QueryString: false
+            Cookies:
+              Forward: none
+        Origins:
+          - Id: origin1
+            DomainName: !Ref OriginDomain1
+            OriginPath: !Ref OriginPath1
+            CustomOriginConfig:
+              HTTPPort: 80
+              HTTPSPort: 443
+              OriginProtocolPolicy: https-only
+          - Id: origin2
+            DomainName: !If
+              - HasOrigin2
+              - !Ref OriginDomain2
+              - !Ref "AWS::NoValue"
+            OriginPath: !Ref OriginPath2
+            CustomOriginConfig:
+              HTTPPort: 80
+              HTTPSPort: 443
+              OriginProtocolPolicy: https-only
+          - Id: origin3
+            DomainName: !If
+              - HasOrigin3
+              - !Ref OriginDomain3
+              - !Ref "AWS::NoValue"
+            OriginPath: !Ref OriginPath3
+            CustomOriginConfig:
+              HTTPPort: 80
+              HTTPSPort: 443
+              OriginProtocolPolicy: https-only
+          - Id: origin4
+            DomainName: !If
+              - HasOrigin4
+              - !Ref OriginDomain4
+              - !Ref "AWS::NoValue"
+            OriginPath: !Ref OriginPath4
+            CustomOriginConfig:
+              HTTPPort: 80
+              HTTPSPort: 443
+              OriginProtocolPolicy: https-only
+          - Id: origin5
+            DomainName: !If
+              - HasOrigin5
+              - !Ref OriginDomain5
+              - !Ref "AWS::NoValue"
+            OriginPath: !Ref OriginPath5
+            CustomOriginConfig:
+              HTTPPort: 80
+              HTTPSPort: 443
+              OriginProtocolPolicy: https-only
+        ViewerCertificate:
+          AcmCertificateArn: !Ref Certificate
+          SslSupportMethod: sni-only
+
+Conditions:
+  HasOrigin2: !Not [!Equals [!Ref OriginDomain2, ""]]
+  HasOrigin3: !Not [!Equals [!Ref OriginDomain3, ""]]
+  HasOrigin4: !Not [!Equals [!Ref OriginDomain4, ""]]
+  HasOrigin5: !Not [!Equals [!Ref OriginDomain5, ""]]
+
+Outputs:
+  CloudFrontDistributionId:
+    Description: The ID of the CloudFront distribution.
+    Value: !Ref CloudFrontDistribution
+  CloudFrontDomainName:
+    Description: The domain name of the CloudFront distribution.
+    Value: !GetAtt CloudFrontDistribution.DomainName

--- a/.binary-repo/.github/aws/iam.cfn.yml
+++ b/.binary-repo/.github/aws/iam.cfn.yml
@@ -1,0 +1,105 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: |
+  CFN template: QGDS-Bootstrap5-${ENV} i.e. QGDS-Bootstrap5-DEV
+  CloudFormation template to create IAM role for GitHub Actions OIDC with permissions to sync an S3 bucket.
+  See https://aws.amazon.com/blogs/security/use-iam-roles-to-connect-github-actions-to-actions-in-aws/
+  And https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-amazon-web-services
+
+Parameters:
+  Environment:
+    Type: String
+    Default: 'DEV'
+    Description: Which environment this role is for (DEV|TEST|STAGING|PROD)
+  GitHubOrg:
+    Type: String
+    Description: GitHub organization or user name.
+    Default: 'qld-gov-au'
+  RepoName:
+    Type: String
+    Description: GitHub repository name.
+    Default: 'qgds-Bootstrap5-release'
+  Branch1:
+    Type: String
+    Description: Main branch name.
+    Default: 'main'
+  Branch2:
+    Type: String
+    Description: Alt branch name.
+    Default: 'develop'
+  S3BucketName:
+    Type: 'AWS::SSM::Parameter::Value<String>'
+    Default: '/config/QGDS-Core/DEV/S3BucketName'
+    Description: Name of the S3 bucket.
+  S3BucketPath:
+    Type: 'AWS::SSM::Parameter::Value<String>'
+    Default: '/config/QGDS-Core/DEV/S3BucketPath'
+    Description: Allowed Path to update
+  GitHubOIDCProviderARN:
+    Type: 'AWS::SSM::Parameter::Value<String>'
+    Default: '/config/GitHubOIDCProviderARN'
+    Description: ARN of the GitHubOIDCProvider
+
+Conditions:
+  HasBranch1: !Not [!Equals [!Ref Branch1, ""]]
+  HasBranch2: !Not [!Equals [!Ref Branch2, ""]]
+
+Resources:
+#NOTE: This usually is created once per aws acccount, leave this in as reference
+#  GitHubOIDCProvider:
+#    Type: "AWS::IAM::OIDCProvider"
+#    Properties:
+#      Url: "https://token.actions.githubusercontent.com"
+#      ClientIdList:
+#        - "sts.amazonaws.com"
+#      ThumbprintList:
+#        - "6938fd4d98bab03faadb97b34396831e3780aea1"  # This thumbprint is for GitHub's SSL certificate
+
+  GitHubActionsRole:
+    Type: "AWS::IAM::Role"
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: "Allow"
+            Principal:
+              Federated:
+                - !Ref GitHubOIDCProviderARN
+            Action:
+              - "sts:AssumeRoleWithWebIdentity"
+            Condition:
+              StringEquals:
+                "token.actions.githubusercontent.com:aud": "sts.amazonaws.com"
+                "token.actions.githubusercontent.com:sub": #username
+                  - !Sub "repo:${GitHubOrg}/${RepoName}:environment:${Environment}" #username when from environment deployment
+                  - !If
+                    - HasBranch1
+                    - !Sub "repo:${GitHubOrg}/${RepoName}:ref:refs/heads/${Branch1}"
+                    - !Ref "AWS::NoValue"
+                  - !If
+                    - HasBranch2
+                    - !Sub "repo:${GitHubOrg}/${RepoName}:ref:refs/heads/${Branch2}"
+                    - !Ref "AWS::NoValue"
+                  - !Sub "repo:${GitHubOrg}/${RepoName}:ref:refs/tags/v*"
+      Policies:
+        - PolicyName: "S3SyncPolicy"
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: "Allow"
+                Action:
+                  - "s3:ListBucket"
+                Resource:
+                  - !Sub "arn:aws:s3:::${S3BucketName}"
+                  - !Sub "arn:aws:s3:::${S3BucketName}/*"
+              - Effect: "Allow"
+                Action:
+                  - "s3:PutObject"
+                  - "s3:PutObjectAcl"
+                  - "s3:DeleteObject"
+                Resource:
+                  - !Sub "arn:aws:s3:::${S3BucketName}/${S3BucketPath}*"
+
+Outputs:
+  RoleArn:
+    Description: "The ARN of the IAM role for GitHub Actions."
+    Value: !GetAtt GitHubActionsRole.Arn

--- a/.binary-repo/.github/aws/setup_github_environment.sh
+++ b/.binary-repo/.github/aws/setup_github_environment.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+# Check if correct number of arguments are provided
+if [ "$#" -ne 5 ]; then
+  echo "Usage: $0 <repo_owner> <repo_name> <environment_name> <s3_bucket> <aws_iam_role>"
+  echo "i.e. $0 qld-gov-au qgds-core DEV \"s3bucket/folder\" aws_iam_role"
+  exit 1
+fi
+
+# Assign arguments to variables
+REPO_OWNER="$1"
+REPO_NAME="$2"
+ENV_NAME="$3"
+S3BUCKET="$4"
+AWS_IAM_ROLE="$5"
+
+# Function to check if environment exists
+check_environment() {
+  gh api repos/${REPO_OWNER}/${REPO_NAME}/environments/${ENV_NAME} --jq '.name' > /dev/null 2>&1
+}
+
+# Function to create environment
+create_environment() {
+  gh api repos/${REPO_OWNER}/${REPO_NAME}/environments/${ENV_NAME} --method PUT
+}
+
+# Function to set secret
+set_secret() {
+  local secret_name=$1
+  local secret_value=$2
+  gh secret set ${secret_name} --body "${secret_value}" --env ${ENV_NAME} --repo ${REPO_OWNER}/${REPO_NAME}
+}
+
+# Check if environment exists
+if check_environment; then
+  echo "Environment ${ENV_NAME} already exists in repository ${REPO_OWNER}/${REPO_NAME}."
+else
+  echo "Creating environment ${ENV_NAME} in repository ${REPO_OWNER}/${REPO_NAME}."
+  create_environment
+fi
+
+# Set secrets
+echo "Setting secrets for environment ${ENV_NAME}."
+set_secret "S3BUCKET" "${S3BUCKET}"
+set_secret "AWS_IAM_ROLE" "${AWS_IAM_ROLE}"
+
+echo "Environment ${ENV_NAME} and secrets have been set successfully."

--- a/.binary-repo/.github/workflows/README.md
+++ b/.binary-repo/.github/workflows/README.md
@@ -1,0 +1,29 @@
+## cdnDeploy script Explanation
+
+### Job deployDEV:
+
+Triggers on push to main, develop, and on tags matching v*
+Contains all the steps you initially provided.
+
+### Job deployTEST:
+
+Depends on deployDEV using the needs keyword.
+Runs only if the branch is develop or main. 
+Uses the same steps as deployDEV.
+
+### Job deploySTAGING:
+
+Triggers on tags matching v* a tag is pushed.
+Uses the same steps as deployDEV.
+
+### Job deployBETA:
+
+Depends on deploySTAGING.
+Triggers on tags matching v*
+Uses the same steps as deployDEV.
+
+### Job deployPROD:
+
+Depends on deploySTAGING.
+Triggers on tags matching v* but requires manual approval (workflow_dispatch with an input).
+Uses the same steps as deployDEV.

--- a/.binary-repo/.github/workflows/cdnAWSDeployment.yml
+++ b/.binary-repo/.github/workflows/cdnAWSDeployment.yml
@@ -1,0 +1,282 @@
+name: Deploy CDN
+
+on:
+  push:
+    branches:
+      - develop
+      - main
+    tags:
+      - v*
+  workflow_dispatch:
+    inputs:
+      updateLatest:
+        description: 'Also update the v1/v1.x.x_latest folders, if false, only version deployed'
+        required: false
+        default: true
+      deploy:
+        description: 'Allow production deployment'
+        required: true
+        type: boolean
+        default: false
+
+jobs:
+  deployDEV:
+    name: Deploy to Dev Environment
+    runs-on: ubuntu-latest
+    environment:
+      name: DEV
+      url: ${{ steps.version.outputs.url }}
+    concurrency:
+      group: dev-deployments
+      cancel-in-progress: false
+
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Save root directory
+        run: echo "REPO_ROOT=$(pwd)" >> $GITHUB_ENV
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '21'
+
+      - name: Get Git Tag or Package.json Version
+        id: version
+        run: bash -x ./.github/workflows/getVersionDetails.sh "dev-static"
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_IAM_ROLE }}
+          aws-region: ap-southeast-2
+
+      - name: Deploy
+        run: |
+          bash -x ./.github/workflows/cdnDeploy.sh repo_root=${{ env.REPO_ROOT }} s3bucket="${{ secrets.S3BUCKET }}" \
+            version=${{ env.version }} updateLatest=true
+
+  deployTEST:
+    name: Deploy to Test Environment
+    runs-on: ubuntu-latest
+    environment:
+      name: TEST
+      url: ${{ steps.version.outputs.url }}
+    concurrency:
+      group: test-deployments
+      cancel-in-progress: false
+    if: ${{ github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/main' }}
+    #delay: '3 days'
+
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Save root directory
+        run: echo "REPO_ROOT=$(pwd)" >> $GITHUB_ENV
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '21'
+
+      - name: Get Git Tag or Package.json Version
+        id: version
+        run: bash -x ./.github/workflows/getVersionDetails.sh "test-static"
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_IAM_ROLE }}
+          aws-region: ap-southeast-2
+
+      - name: Deploy
+        run: |
+          bash -x ./.github/workflows/cdnDeploy.sh repo_root=${{ env.REPO_ROOT }} s3bucket="${{ secrets.S3BUCKET }}" \
+            version=${{ env.version }} updateLatest=true
+
+  deploySTAGING:
+    name: Deploy to Staging Environment
+    runs-on: ubuntu-latest
+    environment:
+      name: STAGING
+      url: ${{ steps.version.outputs.url }}
+    concurrency:
+      group: staging-deployments
+      cancel-in-progress: false
+    if: startsWith(github.ref, 'refs/tags/v')
+    #delay: '3 days'
+
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Save root directory
+        run: echo "REPO_ROOT=$(pwd)" >> $GITHUB_ENV
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '21'
+
+      - name: Get Git Tag or Package.json Version
+        id: version
+        run: bash -x ./.github/workflows/getVersionDetails.sh "staging-static"
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_IAM_ROLE }}
+          aws-region: ap-southeast-2
+
+      - name: Deploy
+        run: |
+          bash -x ./.github/workflows/cdnDeploy.sh repo_root=${{ env.REPO_ROOT }} s3bucket="${{ secrets.S3BUCKET }}" \
+            version=${{ env.version }} updateLatest=true
+
+  #Legacy naming of staging.
+  deployBETA:
+    name: Deploy to Beta Environment
+    needs: deploySTAGING
+    runs-on: ubuntu-latest
+    environment:
+      name: BETA
+      url: ${{ steps.version.outputs.url }}
+    concurrency:
+      group: beta-deployments
+      cancel-in-progress: false
+
+    if: startsWith(github.ref, 'refs/tags/v')
+
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Save root directory
+        run: echo "REPO_ROOT=$(pwd)" >> $GITHUB_ENV
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '21'
+
+      - name: Get Git Tag or Package.json Version
+        id: version
+        run: bash -x ./.github/workflows/getVersionDetails.sh "beta-static"
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_IAM_ROLE }}
+          aws-region: ap-southeast-2
+
+      - name: Deploy
+        run: |
+          bash -x ./.github/workflows/cdnDeploy.sh repo_root=${{ env.REPO_ROOT }} s3bucket="${{ secrets.S3BUCKET }}" \
+            version=${{ env.version }} updateLatest=true
+
+  deployPRODprep:
+    name: (version only, no latest) Deploy to Prod Environment
+    needs: deploySTAGING
+    runs-on: ubuntu-latest
+    environment:
+      name: PROD
+      url: ${{ steps.version.outputs.url }}
+    concurrency:
+      group: prod-deployments
+      cancel-in-progress: false
+
+    if: startsWith(github.ref, 'refs/tags/v')
+
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Save root directory
+        run: echo "REPO_ROOT=$(pwd)" >> $GITHUB_ENV
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '21'
+
+      - name: Get Git Tag or Package.json Version
+        id: version
+        run: bash -x ./.github/workflows/getVersionDetails.sh "static"
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_IAM_ROLE }}
+          aws-region: ap-southeast-2
+
+      - name: Deploy
+        run: |
+          bash -x ./.github/workflows/cdnDeploy.sh repo_root=${{ env.REPO_ROOT }} s3bucket="${{ secrets.S3BUCKET }}" \
+            version=${{ env.version }} updateLatest=true
+
+  deployPROD:
+    name: Deploy to Prod Environment
+    needs: deploySTAGING
+    runs-on: ubuntu-latest
+    environment:
+      name: PROD
+      url: ${{ steps.version.outputs.url }}
+    concurrency:
+      group: prod-deployments
+      cancel-in-progress: false
+
+    #Lock Prod behind manual workflow dispatch flag. Redeploying to staging prior to prod does not hurt in this current usecase
+    if: startsWith(github.ref, 'refs/tags/v') &&  github.event.inputs.deploy == 'true'
+
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Save root directory
+        run: echo "REPO_ROOT=$(pwd)" >> $GITHUB_ENV
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '21'
+
+      - name: Get Git Tag or Package.json Version
+        id: version
+        run: bash -x ./.github/workflows/getVersionDetails.sh "static"
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_IAM_ROLE }}
+          aws-region: ap-southeast-2
+
+      - name: Deploy
+        run: |
+          bash -x ./.github/workflows/cdnDeploy.sh repo_root=${{ env.REPO_ROOT }} s3bucket="${{ secrets.S3BUCKET }}" \
+            version=${{ env.version }} updateLatest=true

--- a/.binary-repo/.github/workflows/cdnAWSDeployment.yml
+++ b/.binary-repo/.github/workflows/cdnAWSDeployment.yml
@@ -231,10 +231,10 @@ jobs:
           role-to-assume: ${{ secrets.AWS_IAM_ROLE }}
           aws-region: ap-southeast-2
 
-      - name: Deploy
+      - name: Deploy (package only)
         run: |
           bash -x ./.github/workflows/cdnDeploy.sh repo_root=${{ env.REPO_ROOT }} s3bucket="${{ secrets.S3BUCKET }}" \
-            version=${{ env.version }} updateLatest=true
+            version=${{ env.version }} updateLatest=false
 
   deployPROD:
     name: Deploy to Prod Environment

--- a/.binary-repo/.github/workflows/cdnAWSManualOrRollBack.yml
+++ b/.binary-repo/.github/workflows/cdnAWSManualOrRollBack.yml
@@ -1,0 +1,80 @@
+name: Deploy CDN (manual/rollback)
+
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: 'Deployment environment'
+        required: true
+        default: 'DEV'
+        type: choice
+        options:
+          - DEV
+          - TEST
+          - STAGING
+          - BETA
+          - PROD
+      updateLatest:
+        description: 'Update the 1.x.x_latest folders (true/false), if not set will be true if is a version'
+        default: 'false'
+        type: choice
+        options:
+          - 'true'
+          - 'false'
+      purgeVersion:
+        description: 'Optional Version to delete'
+        required: false
+        type: text
+      purgeOnly:
+        description: 'Don\t deploy after purge'
+        type: boolean
+        default: false
+      dryRun:
+        description: 'Dry Run deployment (set to false to deploy)'
+        required: true
+        type: boolean
+        default: true
+
+jobs:
+  deploy:
+    name: Deploy to ${{ github.event.inputs.environment }} Environment
+    runs-on: ubuntu-latest
+    environment:
+      name: ${{ github.event.inputs.environment }}
+      url: ${{ steps.version.outputs.url }}
+    concurrency:
+      group: ${{ github.event.inputs.environment }}-deployments
+      cancel-in-progress: false
+
+    permissions:
+      id-token: write #Needed for AWS role switch
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '21'
+
+      - name: Get Git Tag or Package.json Version
+        id: version
+        run: bash -x ./.github/workflows/getVersionDetails.sh "dev-static"
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_IAM_ROLE }}
+          aws-region: ap-southeast-2
+
+      - name: Save root directory
+        run: echo "REPO_ROOT=$(pwd)" >> $GITHUB_ENV
+
+      - name: Deploy
+        run: |
+          bash -x ./.github/workflows/cdnDeploy.sh repo_root=${{ env.REPO_ROOT }} s3bucket="${{ secrets.S3BUCKET }}" \
+            version=${{ env.version }} updateLatest=${{ github.event.inputs.updateLatest }} purgeVersion=${{ github.event.inputs.purgeVersion }} \
+            dry_run=${{  github.event.inputs.dryRun }}
+

--- a/.binary-repo/.github/workflows/cdnDeploy.sh
+++ b/.binary-repo/.github/workflows/cdnDeploy.sh
@@ -1,0 +1,132 @@
+#!/bin/bash
+
+# Usage: ./cdnDeploy.sh repo_root=<REPO_ROOT> s3bucket=<S3BUCKET> version=<VERSION> updateLatest=<TRUE|FALSE>
+
+# Parse command line arguments
+UPDATE_LATEST=false  # Default updateLatest value
+DRY_RUN=false #default
+
+# Parse additional arguments (version and updateLatest)
+for arg in "${@:1}"; do
+    case "$arg" in
+        dry_run=*)
+            DRY_RUN="${arg#*=}"
+            ;;
+        repo_root=*)
+            REPO_ROOT="${arg#*=}"
+            ;;
+        s3bucket=*)
+            S3BUCKET="${arg#*=}"
+            ;;
+        version=*)
+            VERSION="${arg#*=}"
+            ;;
+        updateLatest=*)
+            UPDATE_LATEST="${arg#*=}"
+            ;;
+        purgeVersion=*)
+            PURGE_VERSION="${arg#*=}"
+            ;;
+        purgeOnly=*)
+            PURGE_ONLY="${arg#*=}"
+            ;;
+        *)
+            echo "Ignoring unknown argument: $arg"
+            ;;
+    esac
+done
+
+aws_dry_run=""
+if [[ "$DRY_RUN" == "true" ]]; then
+  echo "Dry Run enabled";
+  aws_dry_run=" --dryrun "
+fi
+
+# Check if VERSION is "-1"
+if [[ "$VERSION" == "-1" ]]; then
+    echo "Error: Version not set. Exiting script."
+    exit 1
+fi
+
+### PURGE COMPONENT
+if [[ "$PURGE_VERSION" != "" ]]; then
+  echo "PURGING version $PURGE_VERSION"
+  IFS='.' read -r PURGE_MAJOR PURGE_MINOR PURGE_PATCH <<< "$PURGE_VERSION"
+  echo "Major: $PURGE_MAJOR"
+  echo "Minor: $PURGE_MINOR"
+  echo "Patch: $PURGE_PATCH"
+  if [[ -z "$PURGE_MAJOR" || -z "$PURGE_MINOR" || -z "$PURGE_PATCH" ]]; then
+    echo "Won't purge, invalid version provided" >> $GITHUB_STEP_SUMMARY
+    exit 1;
+  fi
+
+  echo "Purging ${PURGE_MAJOR}/${PURGE_VERSION} from S3 only" >> $GITHUB_STEP_SUMMARY
+  if [[ "$UPDATE_LATEST" != "true" || "$PURGE_ONLY" == "true" ]]; then
+  echo "If you wish to replace ${PURGE_MAJOR}/${PURGE_MAJOR}.x.x-latest, ${PURGE_MAJOR}/${PURGE_MAJOR}.${PURGE_MINOR}.x-latest then set UPDATE_LATEST to true" >> $GITHUB_STEP_SUMMARY
+  fi
+
+
+  aws s3 rm $aws_dry_run --recursive s3://${S3BUCKET}/${PURGE_MAJOR}/${PURGE_VERSION}
+
+
+  if [[ "$PURGE_ONLY" == "true" ]]; then
+    echo "Purge $aws_dry_run $PURGE_VERSION complete, requested to not deploy new version" >> $GITHUB_STEP_SUMMARY
+    exit 0
+  fi
+
+fi
+
+
+### DEPLOY COMPONENT
+
+# Convert UPDATE_LATEST to lowercase for case-insensitive comparison
+UPDATE_LATEST=$(echo "$UPDATE_LATEST" | tr '[:upper:]' '[:lower:]')
+
+IFS='.' read -r MAJOR MINOR PATCH <<< "$VERSION"
+echo "Major: $MAJOR"
+echo "Minor: $MINOR"
+echo "Patch: $PATCH"
+
+echo "Environment Name: $ENVIRONMENT_NAME"
+echo "S3 Bucket: $S3BUCKET"
+echo "Version: $VERSION"
+echo "Major Version: $MAJOR"
+echo "Update Latest: $UPDATE_LATEST"
+
+# Create a working directory; the workspace may be filled with other important
+# files.
+#
+WORK_DIR="${INPUT_WORKDIR:-$(mktemp -d "${HOME}/gitrepo.XXXXXX")}"
+[ -z "${WORK_DIR}" ] && echo >&2 "::error::Failed to create temporary working directory" && exit 1
+git config --global --add safe.directory "${WORK_DIR}" || exit 1
+cd "${WORK_DIR}" || exit 1
+
+
+
+# Create the target directory (if necessary) and copy files from source.
+#
+TARGET_PATH="${WORK_DIR}/${TARGET_FOLDER}"
+echo "Populating ${TARGET_PATH}"
+
+mkdir -p "${TARGET_PATH}" || exit 1
+
+if [[ "$UPDATE_LATEST" == "true" ]]; then
+  #major
+  MAJOR_LATEST="${MAJOR}/${MAJOR}.x.x-latest"
+  mkdir -p "${TARGET_PATH}/${MAJOR_LATEST}" || exit 1
+  rsync -a --quiet --delete --exclude ".git" --exclude ".github" "${REPO_ROOT}/" "${TARGET_PATH}/${MAJOR_LATEST}" || exit 1
+  aws s3 sync $aws_dry_run --delete "${TARGET_PATH}/${MAJOR_LATEST}" s3://$S3BUCKET/${MAJOR_LATEST}
+  #minor
+  MINOR_LATEST="${MAJOR}/${MAJOR}.${MINOR}.x-latest"
+  mkdir -p "${TARGET_PATH}/${MINOR_LATEST}" || exit 1
+  rsync -a --quiet --delete --exclude ".git" --exclude ".github" "${REPO_ROOT}/" "${TARGET_PATH}/${MINOR_LATEST}" || exit 1
+  aws s3 sync $aws_dry_run --delete "${TARGET_PATH}/${MINOR_LATEST}"  s3://$S3BUCKET/${MINOR_LATEST}
+fi
+
+#tag
+mkdir -p "${TARGET_PATH}/${MAJOR}/${VERSION}"
+rsync -a --quiet --delete --exclude ".git" --exclude ".github" "${REPO_ROOT}/" "${TARGET_PATH}/${MAJOR}/${VERSION}" || exit 1
+aws s3 sync $aws_dry_run --delete "${TARGET_PATH}/${MAJOR}/${VERSION}" s3://$S3BUCKET/${MAJOR}/${VERSION}
+
+
+echo "Deployment $VERSION completed" >> $GITHUB_STEP_SUMMARY

--- a/.binary-repo/.github/workflows/getVersionDetails.sh
+++ b/.binary-repo/.github/workflows/getVersionDetails.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+REF="${GITHUB_BASE_REF:-${GITHUB_REF}}"
+TAG_VALUE=${GITHUB_REF/refs\/tags\//}
+
+#If on a tag, use the tagged version as source of truth.
+if [[ "$GITHUB_REF" == "${GITHUB_REF/refs\/tags\//}"  ]]; then
+  echo "Is not a tag"
+  version=v$(node -pe 'require("./package.json").version')
+  echo "version=${version}" >> $GITHUB_ENV
+else
+#Second best case := package version.
+  version=${TAG_VALUE}
+  echo "version=${version}" >> $GITHUB_ENV
+fi
+
+IFS='.' read -r MAJOR MINOR PATCH <<< "$version"
+echo "url='https://$1.qgov.net.au/./qgds-core/${MAJOR}/${version}'" >> $GITHUB_OUTPUT

--- a/.binary-repo/README.md
+++ b/.binary-repo/README.md
@@ -1,5 +1,7 @@
-# Queensland Online Design System development space - Binary Repo
+# Queensland Online Design System Bootstrap5 - Binary Repo
 
 This repository provides a bundled CSS/JS
 
 See https://qld-gov-au.github.io/qgds-bootstrap5/ for source repository
+
+This repo is also used to deploy to CDN domains.

--- a/.github/workflows/compile.js.yml
+++ b/.github/workflows/compile.js.yml
@@ -80,23 +80,24 @@ jobs:
           name: Package
           path: ./dist
 
-
       - name: Extract branch name
         shell: bash
-        run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
+        run: echo "branch=${GITHUB_REF#refs/heads/}" >> $GITHUB_OUTPUT
         id: extract_branch
 
       - name: display branch name
         shell: bash
         run: echo "${{ steps.extract_branch.outputs.branch }}"
 
-
-      - name: setup Publish
+      - name: setup Publish with details for binary repo including package.json for reference
         run: |
           set -x
-          cp -r ./binary-repo/* ./dist
+          cp package.json ./dist
+          mkdir ./dist/.github
+          cp -r ./.binary-repo/* ./dist
+          cp -r ./.binary-repo/.github/* ./dist/.github
 
-      - name: Publish qgds-qol-dist
+      - name: Publish qgds-bootstrap5-release
         uses: qld-gov-au/gha-publish-to-git@master
         with:
           repository: ${{ vars.TARGET_REPO }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,13 @@ on:
     tags:
       - v*.*.*
 
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: write
+  pages: write
+  actions: read
+  id-token: write
+
 jobs:
   release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This includes the ability auto deploy to dev/test environment on develop/main push.
On a tag push, it will propergate to all environments and only to prod as version only (no latest touched).
A manual release needs to created to push "v*/v*.x.x-latest" to prod domain.

There is a rollback/manual workflow which also includes ability to purge a version. Note: A version release is the only way to update "v*/v*x.x.-latest" folders.

The https://github.com/qld-gov-au/qgds-bootstrap5-cdn repo a DR recovery repo on what should be in there based on the versions released.