### PR TITLE
[QOLOE-272]Turn off browser's autocomplete on Search input

### DIFF
--- a/src/components/bs5/searchInput/searchInput.hbs
+++ b/src/components/bs5/searchInput/searchInput.hbs
@@ -6,7 +6,7 @@
     <div class="qld-search-input {{customClass}}">
 
         <input id="{{ inputID }}" name=" {{ inputName }}" class="form-control" type="text" placeholder="{{placeholder}}"
-            aria-label="{{ ariaLabel }}" {{#each tags}} data-{{@key}}="{{this}}" {{/each}} />
+            autocomplete="off" aria-label="{{ ariaLabel }}" {{#each tags}} data-{{@key}}="{{this}}" {{/each}} />
 
         <button class="btn btn-primary" type="{{ buttonType }}" id="{{ buttonID }}">
             <span class="btn-icon"></span>


### PR DESCRIPTION
HOTFIX:
This changes is to turn-off browser's autocomplete on Search input, by adding attribute `autocomplete="off"`.

JIRA:
https://ssq-qol.atlassian.net/browse/QOLOE-272

Screenshot:
![image-20240612-143939](https://github.com/qld-gov-au/qgds-bootstrap5/assets/8241421/3b30d521-5fc5-42a1-86b8-1809089a06d7)


