### PR TITLE
[QOLOE-268] Set responsive width on header's dropdown menu.

### DIFF
--- a/src/components/bs5/navbar/_icons.scss
+++ b/src/components/bs5/navbar/_icons.scss
@@ -46,8 +46,11 @@
             }
 
             a.dropdown-item {
+                position: relative;
                 .chevron__icon {
-                    float: right;
+                    position: absolute;
+                    top: 1.15rem;
+                    right: 0;
                 }
             }
         }

--- a/src/components/bs5/navbar/navbar.hbs
+++ b/src/components/bs5/navbar/navbar.hbs
@@ -64,7 +64,7 @@
                             {{#each navigation_items}}
                             <li class="col-lg-4 col-sm-12">
                                 <a href="{{target_url}}" class="dropdown-item">
-                                    {{title}}
+                                    <span class="dropdown-item__text">{{title}}</span>
                                     <svg class="chevron__icon">
                                         <use href="{{@root.metadata.options.icon-root}}#qld__icon__arrow-right"></use>
                                     </svg>

--- a/src/components/bs5/navbar/navbar.scss
+++ b/src/components/bs5/navbar/navbar.scss
@@ -82,6 +82,7 @@
 
 
     &-collapse {
+        position: relative;
 
         @include media-breakpoint-down(md) {
             width: 20rem;
@@ -293,7 +294,9 @@
         }
     }
 
-    .dropdown { 
+    .dropdown {
+        position: static;
+
         &-menu {
             background-color: var(--#{$prefix}navbar-dropdown-bg-color);
             
@@ -305,7 +308,7 @@
             @include media-breakpoint-up(lg) {
                 left: 0;
                 right: 0;
-                width: 1320px; //TO DO: FIX
+                width: 100%;
                 padding: 3rem 4rem;
                 margin-top: 0.5rem;
                 margin-left: -4rem;
@@ -330,8 +333,6 @@
                     pointer-events: none; // so that pseudo-element isn't clickable
                 }
             }
-
-            
 
             @include media-breakpoint-down(lg) {
                 border-radius: 0;
@@ -402,6 +403,12 @@
                         padding: 1rem 0;
                         color: var(--#{$prefix}navbar-link-color);
                         border-bottom: solid 1px var(--#{$prefix}navbar-border-color);
+                        white-space: normal;
+
+                        .dropdown-item__text {
+                            display: inline-block;
+                            margin-right: 1.5rem;
+                        }
 
                         &:active {
                             background-color: transparent;
@@ -438,7 +445,6 @@
 
                         @include media-breakpoint-down(lg) {
                             padding: 1rem;
-                            white-space: normal;
                             overflow-wrap: break-word;
                         }
                     }


### PR DESCRIPTION
The dropdown menu's width is now set to be fully responsive to browser's width, on desktop viewports.

Example on Large viewport:
<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img width="656" alt="Before - Large breakpoint - 992px" src="https://github.com/qld-gov-au/qgds-bootstrap5/assets/8241421/ba95a803-98d2-4740-8b19-09fffd207358" border="1"></td>
<td><img width="656" alt="After - Large breakpoint - 992px" src="https://github.com/qld-gov-au/qgds-bootstrap5/assets/8241421/d3dc3fc7-0bc4-4102-9545-8cbda78258ce" border="1"></td>
</tr>
</table>


JIRA:
https://ssq-qol.atlassian.net/issues/QOLOE-268