### PR TITLE
Clean up initilization system of partials. handlebarsHelpers and handlebarsPartials are modules that need to be called handlebarsHelpers(HandleBars)

### DIFF
--- a/.esbuild/plugins/qgds-plugin-copy-assets.js
+++ b/.esbuild/plugins/qgds-plugin-copy-assets.js
@@ -18,13 +18,14 @@ export default function copyPlugin() {
         to: ["./dist/sample-data/"],
       },
       {
-        from: ["./src/js/handlebars*"],
-        to: ["./dist/assets/js"],
+        from: ["./src/js/handlebars.helpers.js"],
+        to: ["./dist/assets/js/handlebars.helpers.js"],
       },
       {
-        from: ["./src/js/handlebars*"],
+        from: ["./src/js/handlebars.*"],
         to: ["./dist/components/"],
       },
+
       { from: ["./src/assets/img/*"], to: ["./dist/assets/img"] },
     ],
   });

--- a/esbuild.js
+++ b/esbuild.js
@@ -52,7 +52,7 @@ const buildConfig = {
     },
     {
       in: "./src/js/handlebars.init.js",
-      out: "./components/handlebars.init.min",
+      out: "./assets/js/handlebars.init.min",
     },
   ],
 

--- a/esbuild.js
+++ b/esbuild.js
@@ -48,7 +48,11 @@ const buildConfig = {
     },
     {
       in: "./src/js/handlebars.init.js",
-      out: "./components/handlebars.init.bundle",
+      out: "./components/handlebars.init.min",
+    },
+    {
+      in: "./src/js/handlebars.init.js",
+      out: "./components/handlebars.init.min",
     },
   ],
 

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "qld.bootstrap.min.js": "./dist/assets/js/qld.bootstrap.min.js",
     "qld.bootstrap.css": "./dist/assets/css/qld.bootstrap.css",
     "handlebars.helpers.bundle.js": "./dist/components/handlebars.helpers.bundle.js",
-    "handlebars.init.js": "./dist/components/handlebars.init.js",
+    "handlebars.init.min.js": "./dist/components/handlebars.init.min.js",
     "bootstrap.min.js": "./dist/assets/js/boostrap.min.js"
   }
 }

--- a/src/components/bs5/breadcumbsWrapper/breadcrumbsWrapper.stories.js
+++ b/src/components/bs5/breadcumbsWrapper/breadcrumbsWrapper.stories.js
@@ -1,5 +1,6 @@
 import { forGov } from "../breadcrumbs/breadcrumbs.data.json";
 import { BreadcrumbsWrapperTest } from "./breadcrumbsWrapper.test.js";
+// eslint-disable-next-line no-unused-vars
 import init from "../../../js/handlebars.init.js"; //self init's when loaded
 
 const defaultData = { breadcrumbs: forGov };

--- a/src/components/bs5/breadcumbsWrapper/breadcrumbsWrapper.stories.js
+++ b/src/components/bs5/breadcumbsWrapper/breadcrumbsWrapper.stories.js
@@ -1,14 +1,13 @@
 import { forGov } from "../breadcrumbs/breadcrumbs.data.json";
 import { BreadcrumbsWrapperTest } from "./breadcrumbsWrapper.test.js";
-import init from "../../../js/handlebars.init.js";
-import Handlebars from "handlebars";
+import init from "../../../js/handlebars.init.js"; //self init's when loaded
 
 const defaultData = { breadcrumbs: forGov };
 
 export default {
   title: "!Layout/Components/Breadcrumbs Wrapper",
   render: (args) => {
-    init(Handlebars)
+
     return new BreadcrumbsWrapperTest(args).html;
   },
   args: defaultData,

--- a/src/components/bs5/searchInput/search.functions.js
+++ b/src/components/bs5/searchInput/search.functions.js
@@ -114,9 +114,9 @@ export async function showSuggestions(value = '', isDefault = false, form) {
         <div class="suggestions-category mt-2">
           <strong>Suggestions</strong>
           <ul class="mt-2">${fetchedSuggestions.slice(0, 4).map(item => {
-            const highlightedText = item.replace(new RegExp(`(${value})`, 'gi'), '<strong>$1</strong>');
-            return `<li><a href="#">${highlightedText}</a></li>`;
-          }).join('')}</ul>
+    const highlightedText = item.replace(new RegExp(`(${value})`, 'gi'), '<strong>$1</strong>');
+    return `<li><a href="#">${highlightedText}</a></li>`;
+  }).join('')}</ul>
         </div>`;
       dynamicSuggestionsContainer.style.display = 'block';
       createPopper(searchInput, suggestions, {

--- a/src/js/handlebars.helpers.js
+++ b/src/js/handlebars.helpers.js
@@ -90,15 +90,3 @@ export default function handlebarsHelpers(handlebars) {
     return handlebars.helpers.formatDate(dateToFormat);
   });
 }
-
-//Only load once if Handlebars is available
-if(typeof(Handlebars) !== 'undefined') {
-  this.registedHandlebarsHelpers = undefined;
-  if (typeof this.registedHandlebarsHelpers === 'undefined') {
-    // eslint-disable-next-line no-undef
-    handlebarsHelpers(Handlebars);
-    this.registedHandlebarsHelpers = true;
-  }
-} else {
-  console.log("HandleBars is undefined, did not load helpers")
-}

--- a/src/js/handlebars.init.js
+++ b/src/js/handlebars.init.js
@@ -17,16 +17,18 @@ export default function init(handlebars = Handlebars) {
   }
 
   if(typeof(handlebars) !== 'undefined') {
-    //only load once
     if (!isHandlebarsHelpersAndPartialsRegistered) {
-      handlebarsHelpers(handlebars);
-      handlebarsPartials(handlebars);
       isHandlebarsHelpersAndPartialsRegistered = true;
     } else {
-      console.log("HandleBars Helpers And Partials already loaded")
+      console.log("HandleBars Helpers And Partials already loaded, loading again")
     }
+    handlebarsHelpers(handlebars);
+
+    handlebarsPartials(handlebars);
   } else {
     console.log("Handlebars not found, init failed");
   }
 }
+
+init();
 

--- a/src/js/handlebars.init.js
+++ b/src/js/handlebars.init.js
@@ -7,6 +7,8 @@ import Handlebars from "handlebars";
  *
  * @param {Handlebars} handlebars
  */
+let isHandlebarsHelpersAndPartialsRegistered = false;
+
 export default function init(handlebars = Handlebars) {
   if (typeof(handlebars) === 'undefined') {
     if(typeof(Handlebars) !== 'undefined') {
@@ -16,15 +18,12 @@ export default function init(handlebars = Handlebars) {
 
   if(typeof(handlebars) !== 'undefined') {
     //only load once
-    if (typeof handlebarsHelpers.registeredHandlebarsHelpers === 'undefined') {
+    if (!isHandlebarsHelpersAndPartialsRegistered) {
       handlebarsHelpers(handlebars);
-      handlebarsHelpers.registeredHandlebarsHelpers = true;
-    }
-    //only load once
-    if (typeof handlebarsPartials.registeredHandlebarsPartials === 'undefined') {
       handlebarsPartials(handlebars);
-      handlebarsPartials.registeredHandlebarsPartials = true;
-      console.log('partials loaded');
+      isHandlebarsHelpersAndPartialsRegistered = true;
+    } else {
+      console.log("HandleBars Helpers And Partials already loaded")
     }
   } else {
     console.log("Handlebars not found, init failed");


### PR DESCRIPTION
Copy all handlebars to components since it references handlebar partials which can't work when in assets/js.
handlebars.helpers.js still in same place during transition but handlebars are all in the components parts.

dist/components/handlebars.init.min.js is the bundled full version. 