### PR TITLE
[QOLOE-268] Fix outline on dropdown menu item.

### DIFF
--- a/src/components/bs5/navbar/navbar.scss
+++ b/src/components/bs5/navbar/navbar.scss
@@ -358,8 +358,8 @@
                 &[data-bs-popper] {
                     margin-top: 9px !important; // Had to use important for override to work
                 }
-
-                ::before {
+                
+                &.show::before {
                     position: absolute;
                     content: ' ';
                     height: 6px;


### PR DESCRIPTION
Fix the outline is missing top border.

**Before:**
![Before - outline](https://github.com/qld-gov-au/qgds-bootstrap5/assets/8241421/fead16de-d0ed-47f3-96da-918b2bcc1acb)

**After:**
![After - outline](https://github.com/qld-gov-au/qgds-bootstrap5/assets/8241421/7fd6a222-8fee-43d3-bb92-3dbd62e76e20)
