### PR TITLE
WIP: Updating half rem to make clickable area larger and double line …

### DIFF
--- a/src/components/bs5/searchInput/searchInput.scss
+++ b/src/components/bs5/searchInput/searchInput.scss
@@ -100,6 +100,7 @@
                     min-height: 3rem;
                     list-style: none;
                     cursor: pointer;
+                    margin-top: 0;
 
                     a {
                         vertical-align: middle;

--- a/src/components/bs5/searchInput/searchInput.scss
+++ b/src/components/bs5/searchInput/searchInput.scss
@@ -41,7 +41,7 @@
             ul {
                 li {
                     a {
-                        padding: 0 1rem;
+                        padding: 0.5rem 1rem;
                         display: inline-block;
                     }
                 }


### PR DESCRIPTION
Makes the double line result neater and clickable area slightly larger:

Before:
<img width="391" alt="image" src="https://github.com/qld-gov-au/qgds-bootstrap5/assets/122584447/d07045dc-33d8-4359-b92b-3d67bb1a9907">

After:
<img width="385" alt="Screenshot 2024-06-26 at 11 16 44 am" src="https://github.com/qld-gov-au/qgds-bootstrap5/assets/122584447/70f99acc-c857-4a1d-8658-628f1893c50e">

Why margin-top:0 was added:
<img width="753" alt="image" src="https://github.com/qld-gov-au/qgds-bootstrap5/assets/122584447/275eb52a-70da-4163-8096-c24bff724c95">

