### PR TITLE
Removed unnecessary visited link styles from breadcrumbs - light and dark theme

### DIFF
--- a/src/components/bs5/breadcrumbs/breadcrumbs.scss
+++ b/src/components/bs5/breadcrumbs/breadcrumbs.scss
@@ -16,12 +16,19 @@ $breadcrumb-divider-dark-flipped: url("data:image/svg+xml,<svg xmlns='http://www
     --#{$prefix}breadcrumb-bg: transparent;
     --#{$prefix}breadcrumb-margin-bottom: 0;
     --#{$prefix}breadcrumb-padding-y: 1.5rem 0 1rem;
+    --#{$prefix}breadcrumb-visited-link-color: var(--#{$prefix}color-default-color-light-link-default);
+    --#{$prefix}breadcrumb-visited-link-text-decoration-color: var(--#{$prefix}color-default-color-light-underline-default);
+    --#{$prefix}breadcrumb-visited-link-text-decoration-color-hover: var(--#{$prefix}color-default-color-light-underline-default-hover);
+
 
     .dark &,
     .dark-alt & {
         --#{$prefix}breadcrumb-item-active-color: var(--#{$prefix}color-default-color-dark-text-lighter);
         --#{$prefix}breadcrumb-divider: #{escape-svg($breadcrumb-divider-dark)};
         --#{$prefix}breadcrumb-divider-flipped: #{escape-svg($breadcrumb-divider-dark-flipped)};
+        --#{$prefix}breadcrumb-visited-link-color: var(--#{$prefix}color-default-color-dark-link-default);
+    --#{$prefix}breadcrumb-visited-link-text-decoration-color: var(--#{$prefix}color-default-color-dark-underline-default);
+    --#{$prefix}breadcrumb-visited-link-text-decoration-color-hover: var(--#{$prefix}color-default-color-dark-underline-default-hover);
     }
 
 }
@@ -73,6 +80,14 @@ $breadcrumb-divider-dark-flipped: url("data:image/svg+xml,<svg xmlns='http://www
         border: 0;
         padding: 0;
         vertical-align: inherit;
+    }
+
+    a:visited {
+        color: var(--#{$prefix}breadcrumb-visited-link-color);
+        text-decoration-color: var(--#{$prefix}breadcrumb-visited-link-text-decoration-color);
+        &:hover {
+            text-decoration-color: var(--#{$prefix}breadcrumb-visited-link-text-decoration-color-hover);
+        }
     }
 }
 

--- a/src/scss/qld-type.scss
+++ b/src/scss/qld-type.scss
@@ -149,9 +149,11 @@ a,
 a.nav-link {
   text-underline-offset: var(--qld-link-underline-offset);
   text-decoration-thickness: var(--qld-link-underline-thickness);
+  text-decoration-color: var(--#{$prefix}color-default-color-light-underline-default);
 
   &:hover {
     text-decoration-thickness: var(--qld-link-underline-thickness-hover);
+    text-decoration-color: var(--#{$prefix}color-default-color-light-underline-default-hover);
   }
 
     &:visited {


### PR DESCRIPTION
| Before | After |
|:--------|:-------|
|![Screenshot 2024-06-26 at 3 41 27 pm](https://github.com/qld-gov-au/qgds-bootstrap5/assets/950889/a9d984d9-ccb6-4ed1-89d0-623241cfe7c3)|![Screenshot 2024-06-26 at 3 40 34 pm](https://github.com/qld-gov-au/qgds-bootstrap5/assets/950889/b1f92ae9-a0fd-4502-b9a2-2989bdcd6130)|
|![Screenshot 2024-06-26 at 3 41 45 pm](https://github.com/qld-gov-au/qgds-bootstrap5/assets/950889/9e5afed5-66ca-4faa-9008-3528a9e1618f)|![Screenshot 2024-06-26 at 3 40 25 pm](https://github.com/qld-gov-au/qgds-bootstrap5/assets/950889/1afedb96-656f-4e38-a4cb-386cf63581ac)|






