### PR TITLE
Remove top margin from first instance of paragraph tags in a container

### DIFF
--- a/src/scss/qld-type.scss
+++ b/src/scss/qld-type.scss
@@ -99,6 +99,10 @@ body {
   p {
     margin-top: 1.5rem;
     margin-bottom: 0;
+
+    &:first-child {
+      margin-top: 0;
+    }
   }
 
   ul, ol, p {
@@ -112,7 +116,7 @@ body {
 }
 
 // Apply correct bold font-weight
-h1, .h1, h2, .h2, h3, .h3, h4, .h4, h5, .h5, h6, .h6, 
+h1, .h1, h2, .h2, h3, .h3, h4, .h4, h5, .h5, h6, .h6,
 strong, b, th, dt {
   font-weight: $font-weight-bold;
 }
@@ -182,7 +186,7 @@ caption {
   h1, h2, h3, h4, h5, h6 {
     color: var(--#{$prefix}color-default-color-dark-text-heading);
   }
-  
+
 
   body & {
       color: var(--qld-body-color);


### PR DESCRIPTION
Rule on `<p>` tags was adding unintended top margin on every instance, e.g.
![image](https://github.com/qld-gov-au/qgds-bootstrap5/assets/17775683/fbbce417-cd7a-4fe5-b271-5a46679fc906)
![image](https://github.com/qld-gov-au/qgds-bootstrap5/assets/17775683/2751c644-2588-4d05-8c77-f6b41dd39d99)

This removes the top margin from the first instance of a `<p>` inside a container element.