### PR TITLE
QOLOE-222 feedback btn removal fix

### DIFF
--- a/src/components/bs5/footer/footer.scss
+++ b/src/components/bs5/footer/footer.scss
@@ -286,7 +286,7 @@
   .btn.qg-feedback-toggle {
     font-weight: bold;
   }
-  &:has(#feedbackFormIO .formio-component-html1) {
+  &:has(.show #feedbackFormIO .formio-component-html1) {
     #btn-footer-feedback {
       display: none;
       visibility: hidden;


### PR DESCRIPTION
This is a fix for when the user clicks close btn within the feedback form thank you page.
The feedback btn is not visible. This fixes that issue and makes the btn visible again.