### PR TITLE
QOLOE-343 Styling modal body

### DIFF
--- a/src/components/bs5/modal/modal.hbs
+++ b/src/components/bs5/modal/modal.hbs
@@ -21,7 +21,7 @@
       </div>
       {{/if}}
       
-      <div class="modal-body">
+      <div class="modal-body row">
         {{{ content }}}
       </div>
     


### PR DESCRIPTION
https://uat.forgov.qld.gov.au/service-delivery-and-community-support/design-and-deliver-public-services/customer-experience-training/human-centred-design/case-study?layout=qgds&SQ_ACTION=set_design_name&SQ_DESIGN_NAME=qgds

Images viewed larger are not centred in modal. Applying class row to modal-body to fix that.

<img width="884" alt="image" src="https://github.com/qld-gov-au/qgds-bootstrap5/assets/126438691/03d98c87-434f-4a98-8dbe-f7f3044c8b8b">
