### PR TITLE
Allow HTML in CTA labels

### DIFF
--- a/src/components/bs5/header/header.hbs
+++ b/src/components/bs5/header/header.hbs
@@ -179,7 +179,7 @@
                     {{#each sitePreHeader.CTA}}
                         <span {{#if dropdown_enabled}} class="dropdown dropdownCTA" {{/if}}>
                             <a {{#if dropdown_enabled}} id="dropdown{{id}}" role="button" data-bs-toggle="dropdown" aria-expanded="false" class="qld__header__cta-link" href="#" {{else}} href="{{url.value}}" class="qld__header__cta-link" {{/if}}>
-                                <span class="qld__header__cta-link-text">{{text.value}}</span>
+                                <span class="qld__header__cta-link-text">{{{text.value}}}</span>
                                 {{#if dropdown_enabled}}
                                     <svg aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" class="qld__header__cta-link-icon">
                                         <use href="{{@root.icon-root}}#{{@root.icons.chevron_down}}"></use>

--- a/src/components/bs5/navbar/navbar.hbs
+++ b/src/components/bs5/navbar/navbar.hbs
@@ -174,11 +174,11 @@
 
                             <!-- Primary dropdown style and behaviour -->
                             <a class="nav-link first-element" href="{{target_url}}">
-                                {{label}}
+                                {{{label}}}
                             </a>
 
                             <button class="dropdown-toggle second-element" id="menuDropdown-{{id}}" role="button"
-                                aria-controls="" data-bs-toggle="dropdown" aria-expanded="false" 
+                                aria-controls="" data-bs-toggle="dropdown" aria-expanded="false"
                                 aria-label="Toggle navigation">
                                 <svg class="toggle_icon">
                                     <use href="{{@root.metadata.options.icon-root}}#qld__icon__chevron-down"></use>


### PR DESCRIPTION
Allows HTML as the value for a CTA text/label without escaping. Useful when the label needs to be dynamic (such as 'Log in'/'My account') via edge-side include tag.