### PR TITLE
QOLOE-381 card-text fix

### DIFF
--- a/src/components/bs5/card/card.hbs
+++ b/src/components/bs5/card/card.hbs
@@ -43,9 +43,9 @@
                 </h3>
 
                 {{#if description}}
-                <p class="card-text">
+                <div class="card-text">
                     {{{description}}}
-                </p>
+                </div>
                 {{/if}}
 
                 {{#if arrow}}

--- a/src/components/bs5/card/card.scss
+++ b/src/components/bs5/card/card.scss
@@ -237,6 +237,10 @@ $view-all-icon-dark: url("data:image/svg+xml,<svg width='21' height='21' viewBox
         margin-top: 0.5rem;
     }
 
+    .card-text > :last-child {
+        margin-bottom: 0;
+    }
+
     &-single-action,
     &-multi-action {
         box-shadow: var(--#{$prefix}card-box-shadow);


### PR DESCRIPTION
Changes card-text element from a `<p>` to a `<div>` so it can contain complex markup.

Also removes margin from the last child inside card-text container to avoid unintended spacing.