### PR TITLE
QOLOE-200 Fix chevron icon at large screen sizes

### DIFF
--- a/src/components/bs5/breadcrumbs/breadcrumbs.scss
+++ b/src/components/bs5/breadcrumbs/breadcrumbs.scss
@@ -116,7 +116,7 @@ $breadcrumb-divider-dark-flipped: url("data:image/svg+xml,<svg xmlns='http://www
         content: none;
       }
     }
-    &:nth-last-child(2):not(:first-child):before {
+    &:nth-last-child(2):before {
       content: none;
     }
     &.active {


### PR DESCRIPTION
Stops left chevron icon showing on large screens when the current page is at 2nd level of the IA (e.g. 'Home' is both first child and second last child)
![image](https://github.com/qld-gov-au/qgds-bootstrap5/assets/17775683/3485a78a-c74c-4100-9ff7-99655527b3ea)
