### PR TITLE
QOLOE-470 Keep the search suggestions open until focus out

### DIFF
--- a/src/components/bs5/searchInput/search.functions.js
+++ b/src/components/bs5/searchInput/search.functions.js
@@ -92,6 +92,12 @@ export async function showSuggestions(value = '', isDefault = false, form) {
     return;
   }
 
+  if (value.length === 0) {
+    dynamicSuggestionsContainer.innerHTML = '';
+    dynamicSuggestionsContainer.style.display = 'none';
+    return;
+  }
+
   defaultSuggestionsContainer.style.display = 'none';
 
   // Fetch dynamic suggestions if available

--- a/src/components/bs5/searchInput/search.functions.js
+++ b/src/components/bs5/searchInput/search.functions.js
@@ -92,14 +92,6 @@ export async function showSuggestions(value = '', isDefault = false, form) {
     return;
   }
 
-  if (value.length === 0) {
-    defaultSuggestionsContainer.style.display = 'none';
-    dynamicSuggestionsContainer.innerHTML = '';
-    dynamicSuggestionsContainer.style.display = 'none';
-    suggestions.style.display = 'none';
-    return;
-  }
-
   defaultSuggestionsContainer.style.display = 'none';
 
   // Fetch dynamic suggestions if available

--- a/src/components/bs5/searchInput/searchInput.hbs
+++ b/src/components/bs5/searchInput/searchInput.hbs
@@ -12,7 +12,7 @@
         </button>
 
         {{#if suggestions}}
-        <ul class="suggestions suggestions__group">
+        <div class="suggestions suggestions__group">
             <div class="default-suggestions">
                 <div class="suggestions-category mt-2">
                     <strong class="suggestions-category-label">Popular services</strong>
@@ -41,7 +41,7 @@
                 {{/if}}
             </div>
             <div class="dynamic-suggestions"></div>
-        </ul>
+        </div>
         {{/if}}
     </div>
 </div>

--- a/src/components/bs5/searchInput/searchInput.scss
+++ b/src/components/bs5/searchInput/searchInput.scss
@@ -2,7 +2,6 @@
 // Search input - palettes and second hand variables:
 @import './colours';
 // ----------------------------------------------------------------------------------------------------------------------
-
 .qld-search-input {
     //Default state - unfocused, unhovered
     --text-color: var(--qld-dark-grey-muted);
@@ -43,6 +42,7 @@
                     a {
                         padding: 0.5rem 1rem;
                         display: inline-block;
+                        width: 100%;
                     }
                 }
             }


### PR DESCRIPTION
1. The search suggestion dropdown used to stay only for a second and then disappears when tabbing with keyboard. This change leaves it open till the user focus out of the search. Tha is how production behaves at the moment.

2. Make search suggestion outline full width:

Before:
![image](https://github.com/user-attachments/assets/e8626a90-30d6-415a-993d-fecc3bdb6c51)

After:
![image](https://github.com/user-attachments/assets/e9de5589-abe6-4bea-929b-5713bf3f3047)

3. Replacing ul tag with div as there was no list item inside it.
