### PR TITLE
[QOLOE-318]Add bootstrap data-bs-target on Feedback form toggle buttons

### DIFF
--- a/src/components/bs5/footer/footer.hbs
+++ b/src/components/bs5/footer/footer.hbs
@@ -79,7 +79,7 @@
                         </div>
                         <div class="col-xs-12 col-md-6 col-lg-12">
                             <div id="qg-feedback-toggle" class="qg-footer-feedback-wrap">
-                                <a id="btn-footer-feedback" class="btn btn-global-secondary qg-feedback-toggle collapsed" data-bs-toggle="collapse" href="#qg-footer-feedback" role="button" aria-expanded="false" aria-controls="qg-footer-feedback" data-analytics-link-group="qg-feedback">
+                                <a id="btn-footer-feedback" class="btn btn-global-secondary qg-feedback-toggle collapsed" data-bs-toggle="collapse" data-bs-target="#qg-footer-feedback" href="#qg-footer-feedback" role="button" aria-expanded="false" aria-controls="qg-footer-feedback" data-analytics-link-group="qg-feedback">
                                     {{#if feedbackForm.btnTitle}}{{feedbackForm.btnTitle}}{{else}}Leave your feedback{{/if}}
                                 </a>
                                 <div id="qg-footer-feedback" class="qg-footer-feedback__v2 collapse">
@@ -93,7 +93,7 @@
                                         </div>
                                     </div>
                                     <div class="qg-footer-feedback-footer">
-                                        <a class="qg-footer-feedback__close" data-bs-toggle="collapse" href="#qg-footer-feedback" role="button" aria-expanded="true" aria-controls="qg-footer-feedback">Close</a>
+                                        <a class="qg-footer-feedback__close" data-bs-toggle="collapse" data-bs-target="#qg-footer-feedback" href="#qg-footer-feedback" role="button" aria-expanded="true" aria-controls="qg-footer-feedback">Close</a>
                                     </div>
                                 </div>
                             </div>

--- a/src/components/bs5/footer/footerForgov.hbs
+++ b/src/components/bs5/footer/footerForgov.hbs
@@ -53,7 +53,7 @@
                         </div>
                         <div class="col-xs-12 col-md-6 col-lg-12">
                             <div id="qg-feedback-toggle" class="qg-footer-feedback-wrap">
-                                <a id="btn-footer-feedback" class="btn btn-global-secondary qg-feedback-toggle collapsed" data-bs-toggle="collapse" href="#qg-footer-feedback" role="button" aria-expanded="false" aria-controls="qg-footer-feedback" data-analytics-link-group="qg-feedback">
+                                <a id="btn-footer-feedback" class="btn btn-global-secondary qg-feedback-toggle collapsed" data-bs-toggle="collapse" data-bs-target="#qg-footer-feedback" href="#qg-footer-feedback" role="button" aria-expanded="false" aria-controls="qg-footer-feedback" data-analytics-link-group="qg-feedback">
                                     {{ feedbackForm.btnTitle }}
                                 </a>
                                 <div id="qg-footer-feedback" class="qg-footer-feedback__v2 collapse">
@@ -64,7 +64,7 @@
                                         </div>
                                     </div>
                                     <div class="qg-footer-feedback-footer">
-                                        <a class="qg-footer-feedback__close" data-bs-toggle="collapse" href="#qg-footer-feedback" role="button" aria-expanded="true" aria-controls="qg-footer-feedback">Close</a>
+                                        <a class="qg-footer-feedback__close" data-bs-toggle="collapse" data-bs-target="#qg-footer-feedback" href="#qg-footer-feedback" role="button" aria-expanded="true" aria-controls="qg-footer-feedback">Close</a>
                                     </div>
                                 </div>
                             </div>


### PR DESCRIPTION
[QOLOE-318] On Footer Feedback form, add `data-bs-target` on toggle buttons, in order to avoid conflicts on pages with multiple Bootstrap toggle components.

[QOLOE-318]: https://ssq-qol.atlassian.net/browse/QOLOE-318?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ