### PR TITLE
[QOLOE-421] Accessibility: print out descriptive format for duration

### DIFF
--- a/src/components/bs5/video/video.data.json
+++ b/src/components/bs5/video/video.data.json
@@ -4,7 +4,11 @@
     "videoId": "LDU_Txk06tM",
     "videoSize": "col-12",
     "aspectRatio": "16x9",
-    "duration": "3:12",
+    "duration": {
+      "hours": 0,
+      "minutes": 3,
+      "seconds": 12
+    },
     "thumbnail": "https://img.youtube.com/vi/LDU_Txk06tM/sddefault.jpg",
     "urlParams": {
       "autoplay": 0,
@@ -19,7 +23,11 @@
     "videoId": "251763826",
     "videoSize": "col-8",
     "aspectRatio": "4x3",
-    "duration": "5:00",
+    "duration": {
+      "hours": 0,
+      "minutes": 5,
+      "seconds": 0
+    },
     "thumbnail": "./img/banner-example-3-to-2.jpg",
     "urlParams": {
       "autoplay": 0,
@@ -36,7 +44,11 @@
     "videoId": "https://embed.ted.com/talks/lang/en/adam_grosser_a_mobile_fridge_for_vaccines",
     "videoSize": "col-8",
     "aspectRatio": "16x9",
-    "duration": "3:17",
+    "duration": {
+      "hours": 0,
+      "minutes": 3,
+      "seconds": 17
+    },
     "thumbnail": "./img/banner-example-3-to-2.jpg",
     "analyticsTrackingCode": "",
     "description": "<h3>Custom video embed</h3><p>Fusce posuere, magna sed pulvinar ultricies, purus lectus malesuada libero, sit amet commodo magna eros quis urna. Nunc viverra imperdiet enim.</p>",

--- a/src/components/bs5/video/video.data.json
+++ b/src/components/bs5/video/video.data.json
@@ -4,11 +4,7 @@
     "videoId": "LDU_Txk06tM",
     "videoSize": "col-12",
     "aspectRatio": "16x9",
-    "duration": {
-      "hours": 0,
-      "minutes": 3,
-      "seconds": 12
-    },
+    "duration": "3:12",
     "thumbnail": "https://img.youtube.com/vi/LDU_Txk06tM/sddefault.jpg",
     "urlParams": {
       "autoplay": 0,
@@ -23,11 +19,7 @@
     "videoId": "251763826",
     "videoSize": "col-8",
     "aspectRatio": "4x3",
-    "duration": {
-      "hours": 0,
-      "minutes": 5,
-      "seconds": 0
-    },
+    "duration": "5:00",
     "thumbnail": "./img/banner-example-3-to-2.jpg",
     "urlParams": {
       "autoplay": 0,
@@ -44,11 +36,7 @@
     "videoId": "https://embed.ted.com/talks/lang/en/adam_grosser_a_mobile_fridge_for_vaccines",
     "videoSize": "col-8",
     "aspectRatio": "16x9",
-    "duration": {
-      "hours": 0,
-      "minutes": 3,
-      "seconds": 17
-    },
+    "duration": "3:17",
     "thumbnail": "./img/banner-example-3-to-2.jpg",
     "analyticsTrackingCode": "",
     "description": "<h3>Custom video embed</h3><p>Fusce posuere, magna sed pulvinar ultricies, purus lectus malesuada libero, sit amet commodo magna eros quis urna. Nunc viverra imperdiet enim.</p>",

--- a/src/components/bs5/video/video.functions.js
+++ b/src/components/bs5/video/video.functions.js
@@ -7,13 +7,13 @@
  * @returns {void}
  */
 export function videoEmbedPlay(event) {
-  event.preventDefault()
+  event.preventDefault();
 
   const thumbnail = event.target,
     component = thumbnail.closest(".video"),
     iframe = component.querySelector(".video-embed iframe")
 
-  component.classList.remove("not-ready")
+  component.classList.remove("not-ready");
 
   // Parse iFrame URL and set the 'autoplay' parameter to 1.
   if (!iframe.classList.contains("video-custom")) {
@@ -22,7 +22,7 @@ export function videoEmbedPlay(event) {
     iframe.src = url.toString();
   }
 
-  iframe.focus()
+  iframe.focus();
 
 }
 

--- a/src/components/bs5/video/video.hbs
+++ b/src/components/bs5/video/video.hbs
@@ -10,15 +10,21 @@
 <section class="video not-ready {{#unless thumbnail}}empty-thumbnail{{/unless}} {{videoSize}}">
     <div class="video-player ratio ratio-{{aspectRatio}}">
 
-        <a href="#" class="video-thumbnail video-controls">
+        <a href="#" class="video-thumbnail video-controls" title="Play Video" 
+            aria-label="Watch video {{#if duration}}- duration {{formatDuration duration "long"}}{{/if}}">
+
             <div class="video-thumbnail-image" style="--thumbnail:url({{thumbnail}})"></div>
 
             <div class="video-nav">
-                <div class="video-watch"><span class="icon"></span><span>Watch</span></div>
+                <div class="video-watch">
+                    <span class="icon"></span><span>Watch</span>
+                </div>
 
-            {{#if duration}}
-                <div title="Video duration" class="video-duration"><span class="icon"></span><span>{{duration}}</span></div>
-            {{/if}}
+                {{#if duration}}
+                    <div title="Video duration" class="video-duration">
+                        <span class="icon"></span><span>{{formatDuration duration}}</span>
+                    </div>
+                {{/if}}
             </div>
         </a>
 

--- a/src/js/handlebars.helpers.js
+++ b/src/js/handlebars.helpers.js
@@ -102,6 +102,63 @@ export default function handlebarsHelpers(handlebars) {
     // Call the formatDate helper with the determined date and format
     return handlebars.helpers.formatDate(dateString, dateToFormat, format);
   });
+
+  /**
+   * Format time duration into a string.
+   *
+   * Supports two formats: "short" and "long".
+   * - Short format: Display the duration in simplified format of "HH:MM:SS". It is the default format.
+   * - Long format: Display the duration in descriptive format of "X hours Y minutes Z seconds".
+   *
+   * @param {Object} duration - Duration object with properties 'hours', 'minutes', and 'seconds'.
+   * @param {String} format - Option for format type 'short' or 'long'. If none provided, 'short' is the defaut value.
+   *
+   * @returns {String} Formatted duration
+   * Examples:
+   * - 03:00:00 - 3 hours
+   * - 03:15:00 - 3 hours 15 minutes
+   * - 01:30:45 - 1 hour 30 minutes 45 seconds
+   * - 02:00:45 - 2 hours 45 seconds
+   * - 07:12 - 7 minutes 12 seconds
+   * - 00:45 - 45 seconds
+   *
+   * Usage:
+   * {{formatDuration duration}}
+   * {{formatDuration duration long}}
+   */
+  handlebars.registerHelper('formatDuration', function(duration, format) {
+    if (!duration) {
+      return "";
+    }
+    const {hours = "", minutes = "", seconds = ""} = duration;
+    let durationString = "";
+    let parts = [];
+
+    // Long format: "X hours Y minutes Z seconds"
+    if (format === "long") {
+      if (hours > 0) {
+        parts.push(`${hours} hour${hours > 1 ? 's' : ''}`);
+      }
+      if (minutes > 0) {
+        parts.push(`${minutes} minute${minutes > 1 ? 's' : ''}`);
+      }
+      if (seconds > 0) {
+        parts.push(`${seconds} second${seconds > 1 ? 's' : ''}`);
+      }
+      durationString = parts.join(" ");
+
+    // Short format: "HH:MM:SS"
+    } else {
+      // Omitting hours when zero
+      if (hours > 0) {
+        parts.push(hours.toString().padStart(2, 0));
+      }
+      parts.push(minutes.toString().padStart(2, 0));
+      parts.push(seconds.toString().padStart(2, 0));
+      durationString = parts.join(":");
+    }
+    return durationString;
+  });
 }
 
 if(typeof(Handlebars) !== 'undefined') {

--- a/src/js/handlebars.helpers.js
+++ b/src/js/handlebars.helpers.js
@@ -110,7 +110,7 @@ export default function handlebarsHelpers(handlebars) {
    * - Short format: Display the duration in simplified format of "HH:MM:SS". It is the default format.
    * - Long format: Display the duration in descriptive format of "X hours Y minutes Z seconds".
    *
-   * @param {Object} duration - Duration object with properties 'hours', 'minutes', and 'seconds'.
+   * @param {Object | String} duration - Duration object with properties: 'hours', 'minutes', and 'seconds'. Duration string: "HH:MM:SS".
    * @param {String} format - Option for format type 'short' or 'long'. If none provided, 'short' is the defaut value.
    *
    * @returns {String} Formatted duration
@@ -124,15 +124,35 @@ export default function handlebarsHelpers(handlebars) {
    *
    * Usage:
    * {{formatDuration duration}}
-   * {{formatDuration duration long}}
+   * {{formatDuration duration "long"}}
    */
   handlebars.registerHelper('formatDuration', function(duration, format) {
+    // Return empty string when there is no duration.
     if (!duration) {
       return "";
     }
-    const {hours = "", minutes = "", seconds = ""} = duration;
+
+    // Nothing to process here when the duration is already in short format string
+    // (to support existing CMS metadata).
+    if (typeof(duration) === 'string' && format !== "long") {
+      return duration;
+    }
+
     let durationString = "";
     let parts = [];
+    // Support for object type 'duration'.
+    let {hours = "", minutes = "", seconds = ""} = duration;
+
+    // Support for string type 'duration'.
+    if (typeof(duration) === 'string') {
+      const durationSplit = duration.split(":");
+      seconds = durationSplit[0];
+      if (durationSplit.length == 2) {
+        [minutes = "", seconds = ""] = durationSplit;
+      } else if (durationSplit.length == 3) {
+        [hours = "", minutes = "", seconds = ""] = durationSplit;
+      }
+    }
 
     // Long format: "X hours Y minutes Z seconds"
     if (format === "long") {

--- a/src/js/handlebars.helpers.js
+++ b/src/js/handlebars.helpers.js
@@ -140,18 +140,20 @@ export default function handlebarsHelpers(handlebars) {
 
     let durationString = "";
     let parts = [];
-    // Support for object type 'duration'.
-    let {hours = "", minutes = "", seconds = ""} = duration;
+    let hours, minutes, seconds;
 
     // Support for string type 'duration'.
     if (typeof(duration) === 'string') {
-      const durationSplit = duration.split(":");
+      const durationSplit = duration.split(":");  
       seconds = durationSplit[0];
       if (durationSplit.length == 2) {
         [minutes = "", seconds = ""] = durationSplit;
       } else if (durationSplit.length == 3) {
         [hours = "", minutes = "", seconds = ""] = durationSplit;
       }
+    } else {
+      // Support for object type 'duration'.
+      [hours = "", minutes = "", seconds = ""] = duration;
     }
 
     // Long format: "X hours Y minutes Z seconds"


### PR DESCRIPTION
[QOLOE-421] Accessibility: print out descriptive format for video duration

## What does this changes do?
It allows voice over to read "Watch video - duration X hours Y minutes Z seconds" when the video link is focused.

![Screenshot 2024-07-25 at 11 16 35 AM](https://github.com/user-attachments/assets/8bea030d-3c5e-4437-b5a2-658e736d6125)
Example for the above video:
- Currently, the voice over reads "Watch 151".
- Fixed version, the voice over will read **"Watch video - duration 1 minute 51 seconds".**



## Video component
- Added attribute `title="Play video"` on video's play <a> link
- Added `aria-label` with description of "Watch video - duration X hours Y minutes Z seconds"

## Handlebar helper
- Added a Handlebar helper to print out time duration into a string in the following formats. 
   - Short format: Display the duration in simplified format of "HH:MM:SS". It is the default format.
      - Omits hours when value is zero - mimicking YouTube duration display
   - Long format: Display the duration in descriptive format of "X hours Y minutes Z seconds".
      - Omits any part with zero value.
- The helper is compatible in the case of any incomplete or zero value provided on the duration object properties.
- Examples:
   * - 03:00:00 - 3 hours
   * - 03:15:00 - 3 hours 15 minutes
   * - 01:30:45 - 1 hour 30 minutes 45 seconds
   * - 02:00:45 - 2 hours 45 seconds
   * - 07:12 - 7 minutes 12 seconds
   * - 00:45 - 45 seconds


## Video json data
This changes supports both existing 'duration' string metadata, as well as an object metadata.
No extra change implementation steps required on Squiz when deploying this code.

String type (existing type on Squiz):
```
   "duration": "3:15"
```

Object type:
```
   "duration": {
      "hours": 0,
      "minutes": 3,
      "seconds": 15
    },
```


[QOLOE-421]: https://ssq-qol.atlassian.net/browse/QOLOE-421?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ