### PR TITLE
[QOLOE-445] Accessibility: aria-label on Close button at the Footer Feedback form.

### DIFF
--- a/src/components/bs5/footer/footer.hbs
+++ b/src/components/bs5/footer/footer.hbs
@@ -93,7 +93,7 @@
                                         </div>
                                     </div>
                                     <div class="qg-footer-feedback-footer">
-                                        <a class="qg-footer-feedback__close" data-bs-toggle="collapse" href="#qg-footer-feedback" role="button" aria-label="Close Feedback Form" aria-controls="qg-footer-feedback">Close</a>
+                                        <a class="qg-footer-feedback__close" data-bs-toggle="collapse" href="#qg-footer-feedback" role="button" aria-label="Close Feedback Form" aria-expanded="true" aria-controls="qg-footer-feedback">Close</a>
                                     </div>
                                 </div>
                             </div>

--- a/src/components/bs5/footer/footer.hbs
+++ b/src/components/bs5/footer/footer.hbs
@@ -93,7 +93,7 @@
                                         </div>
                                     </div>
                                     <div class="qg-footer-feedback-footer">
-                                        <a class="qg-footer-feedback__close" data-bs-toggle="collapse" href="#qg-footer-feedback" role="button" aria-expanded="true" aria-controls="qg-footer-feedback">Close</a>
+                                        <a class="qg-footer-feedback__close" data-bs-toggle="collapse" href="#qg-footer-feedback" role="button" aria-label="Close Feedback Form" aria-controls="qg-footer-feedback">Close</a>
                                     </div>
                                 </div>
                             </div>

--- a/src/components/bs5/footer/footerForgov.hbs
+++ b/src/components/bs5/footer/footerForgov.hbs
@@ -64,7 +64,7 @@
                                         </div>
                                     </div>
                                     <div class="qg-footer-feedback-footer">
-                                        <a class="qg-footer-feedback__close" data-bs-toggle="collapse" href="#qg-footer-feedback" role="button" aria-expanded="true" aria-controls="qg-footer-feedback">Close</a>
+                                        <a class="qg-footer-feedback__close" data-bs-toggle="collapse" href="#qg-footer-feedback" role="button" aria-label="Close Feedback Form" aria-controls="qg-footer-feedback">Close</a>
                                     </div>
                                 </div>
                             </div>

--- a/src/components/bs5/footer/footerForgov.hbs
+++ b/src/components/bs5/footer/footerForgov.hbs
@@ -64,7 +64,7 @@
                                         </div>
                                     </div>
                                     <div class="qg-footer-feedback-footer">
-                                        <a class="qg-footer-feedback__close" data-bs-toggle="collapse" href="#qg-footer-feedback" role="button" aria-label="Close Feedback Form" aria-controls="qg-footer-feedback">Close</a>
+                                        <a class="qg-footer-feedback__close" data-bs-toggle="collapse" href="#qg-footer-feedback" role="button" aria-label="Close Feedback Form" aria-expanded="true" aria-controls="qg-footer-feedback">Close</a>
                                     </div>
                                 </div>
                             </div>


### PR DESCRIPTION
[QOLOE-445] Accessibility: Added aria-label to improve Voice over on Close button at the Footer Feedback form.

![Screenshot 2024-07-26 at 10 12 02 AM](https://github.com/user-attachments/assets/88e7dcec-7df8-4389-90dd-ba2fc14fae7e)


## Current
When Close button is focused, Voice Over reads "Close, expanded, button"

## The fix
Voice Over will read "**Close Feedback Form**, expanded, button".


While on JIRA ticket, the tester requested to remove `aria-expanded`, Bootstrap 5 Collapse will automatically adds aria-expanded regardless, for accessibility purposes.
Adding clearer aria-label will make the button a bit clearer for Voice Over users.

 

[QOLOE-445]: https://ssq-qol.atlassian.net/browse/QOLOE-445?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ