### PR TITLE
QOLOE-441 Removing redundant aria-labelledby from navigation bar

### DIFF
--- a/src/components/bs5/header/header.hbs
+++ b/src/components/bs5/header/header.hbs
@@ -187,7 +187,7 @@
                                 {{/if}}
                             </a>
                             {{#if dropdown_enabled}}
-                            <ul class="dropdown-menu dark" aria-labelledby="dropdown{{id}}" role="list">
+                            <ul class="dropdown-menu dark" role="list">
                                 {{#isType dropdown_options.dropdown_type "list"}}
                                     {{#if dropdown_options.dropdown_config}}
                                         {{#each dropdown_options.dropdown_config.groups}}

--- a/src/components/bs5/navbar/navbar.hbs
+++ b/src/components/bs5/navbar/navbar.hbs
@@ -44,7 +44,7 @@
                         </svg>
                     </a>
                     {{#if navigation_items}}
-                    <ul id="dropdown-menu" class="dropdown-menu" aria-labelledby="menuDropdown" role="menu"
+                    <ul id="dropdown-menu" class="dropdown-menu" role="menu"
                         data-bs-popper="none">
                         <div class="row dropdown-menu__inner">
                             {{#if dropdown_options}}
@@ -109,7 +109,7 @@
                         </button>
 
                         {{#if navigation_items}}
-                        <ul id="dropdown-menu" class="dropdown-menu" aria-labelledby="menuDropdown" role="menu"
+                        <ul id="dropdown-menu" class="dropdown-menu" role="menu"
                             data-bs-popper="none">
                             <div class="row dropdown-menu__inner">
                                 {{#if dropdown_options}}
@@ -187,7 +187,7 @@
                             </button>
 
                             {{#if dropdown_enabled}}
-                            <ul id="dropdown-menu-{{id}}" class="dropdown-menu" aria-labelledby="menuDropdown-{{id}}"
+                            <ul id="dropdown-menu-{{id}}" class="dropdown-menu"
                                 role="menu" data-bs-popper="none">
                                 <div class="row dropdown-menu__inner">
                                     {{#if dropdown_options.dropdown_config.groups}}


### PR DESCRIPTION
'Toggle navigation' was read twice by the screen reader, once when landing on the navigation bar root, another time when landing on the ul containing the navigation items. It was recommended by the a11y auditors to remove aria-labelledby.