### PR TITLE
[QOLOE-412] Accessibility: Fix screenreader for Open and Close buttons on mobile menu

### DIFF
--- a/src/components/bs5/header/header.hbs
+++ b/src/components/bs5/header/header.hbs
@@ -237,7 +237,7 @@
                 {{/if}}
                 <button aria-controls="main-nav" class="qld__header__toggle-main-nav qld__main-nav__toggle--open"
                     data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent"
-                    aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
+                    aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Open menu">
                     <svg aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg"
                         class="qld__icon qld__icon--lg">
                         <use href="{{@root.icon-root}}#{{@root.icons.menu-icon}}"></use>

--- a/src/components/bs5/navbar/navbar.functions.js
+++ b/src/components/bs5/navbar/navbar.functions.js
@@ -90,12 +90,16 @@ export function initializeNavbar() {
       if (headerEl) {
         headerEl.setAttribute('aria-hidden', true);
       }
-    });
+      if (openMenuButton) {
+        openMenuButton.setAttribute('aria-label', 'Close menu');
+      }
+  });
 
     // Once mobile nav has been hidden.
     // Change focus back to Open Menu button and unhide Header from screenreader.
     navbarCollapse.addEventListener('hidden.bs.collapse', function () {
       if (openMenuButton) {
+        openMenuButton.setAttribute('aria-label', 'Open menu');
         openMenuButton.focus();
       }
       if (headerEl) {

--- a/src/components/bs5/navbar/navbar.functions.js
+++ b/src/components/bs5/navbar/navbar.functions.js
@@ -41,6 +41,9 @@ export function initializeNavbar() {
   const dropdownItems = document.querySelectorAll('ul.dropdown-menu');
   const overlay = document.getElementById('overlay');
   const body = document.body;
+  const headerEl = document.querySelector('header');
+  const closeMenuButton = document.querySelector('.navbar__toggle--close');
+  const openMenuButton = document.querySelector('.qld__main-nav__toggle--open');
 
   // Add event listeners to each dropdown item
   if (dropdownItems) {
@@ -66,15 +69,38 @@ export function initializeNavbar() {
   }
 
   if (navbarCollapse) {
-    // Overlay show/hide events
+    // When mobile collapsible-navigation is opened
     navbarCollapse.addEventListener('show.bs.collapse', function () {
       overlay.classList.add('show'); // Show the overlay
       body.style.overflow = 'hidden'; // Prevent background scroll
     });
 
+    // When colapsible navigation is closed
     navbarCollapse.addEventListener('hide.bs.collapse', function () {
       overlay.classList.remove('show'); // Hide the overlay
       body.style.overflow = ''; // Reset body positioning
+    });
+
+    // Once mobile nav has been made visible.
+    // Change focus to Close Menu button and hide Header from screenreader.
+    navbarCollapse.addEventListener('shown.bs.collapse', function () {
+      if (closeMenuButton) {
+        closeMenuButton.focus();
+      }
+      if (headerEl) {
+        headerEl.setAttribute('aria-hidden', true);
+      }
+    });
+
+    // Once mobile nav has been hidden.
+    // Change focus back to Open Menu button and unhide Header from screenreader.
+    navbarCollapse.addEventListener('hidden.bs.collapse', function () {
+      if (openMenuButton) {
+        openMenuButton.focus();
+      }
+      if (headerEl) {
+        headerEl.setAttribute('aria-hidden', false);
+      }
     });
   }
 

--- a/src/components/bs5/navbar/navbar.hbs
+++ b/src/components/bs5/navbar/navbar.hbs
@@ -4,17 +4,21 @@
 <nav id="main-nav" class="navbar navbar-expand-lg" aria-label="Website navigation" role="navigation">
     <div class="container navbar-contain">
         <div class="collapse navbar-collapse" id="navbarSupportedContent">
+
+            {{!-- Header for mobile navigation --}}
             <div class="navbar__header">
                 <h6 class="navbar__heading">Menu</h6>
                 <button aria-controls="main-nav" class="navbar__toggle navbar__toggle--close" data-bs-toggle="collapse"
                     data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent"
-                    aria-expanded="false" aria-label="Close navigation">
+                    aria-expanded="false" aria-label="Close menu">
                     <svg aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" class="qld__icon">
                         <use href="{{metadata.options.icon-root}}#qld__icon__close"></use>
                     </svg>
                     <span class="navbar__toggle-text">Close</span>
                 </button>
             </div>
+            {{!-- End: Header for mobile navigation --}}
+
             <ul class="navbar-nav me-auto mb-2 mb-lg-0">
                 <li class="nav-item nav-item-home">
                     <a class="nav-link {{#if metadata.options.home-active}}nav-link-home-active{{/if}}"

--- a/src/components/bs5/navbar/navbar.scss
+++ b/src/components/bs5/navbar/navbar.scss
@@ -191,6 +191,11 @@
                 }
             }
 
+            &:focus {
+				outline: 3px solid var(--#{$prefix}color-default-color-dark-focus-default);
+				outline-offset: 2px;
+			}
+
             @include media-breakpoint-up(md) {
                 padding: 0.75rem 1rem;
             }

--- a/src/components/bs5/navbar/navbar.scss
+++ b/src/components/bs5/navbar/navbar.scss
@@ -250,6 +250,7 @@
 
             &--close {
                 background-color: transparent;
+                z-index: 100;
 
                 @include media-breakpoint-up(md) {
                     border-width: 2px


### PR DESCRIPTION
[QOLOE-445] Accessibility: Fix screenreader for Open and Close buttons on mobile menu

On Open button, voice over will read "Open Menu, collapsed, button".
![Screenshot 2024-07-31 at 2 18 25 PM](https://github.com/user-attachments/assets/93573d8f-0d68-41c2-8991-6e31a4817f63)


On Close button, voice over will read "Close Menu, expanded, button".
![Screenshot 2024-07-31 at 2 18 36 PM](https://github.com/user-attachments/assets/55f9bf7f-2ee0-4bfa-b6a6-68f819d567b6)

### The issue
Voice Over keeps reading Open button even though the button is not visible and navigation is showing.

### The fix
The fix is to change the focus using Bootstrap Collapse event handler. 
When navigation is showing (and Close button is visible), change the focus to Close button.
This way, the Voice Over will read Close button and stop reading Open button.

 



[QOLOE-445]: https://ssq-qol.atlassian.net/browse/QOLOE-445?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ