### PR TITLE
QOLOE-396 Making select2 fields accessible by screen readers

### DIFF
--- a/src/components/bs5/select/select2.functions.js
+++ b/src/components/bs5/select/select2.functions.js
@@ -1,0 +1,30 @@
+// Making select2 fields accessible by screen readers
+export function handleScreenReaderAccessibility () {
+    var selects = document.getElementsByClassName("select2-search__field");
+    const arr = Array.from(selects);
+    arr.forEach(function(item) {
+        item.addEventListener("keyup", focus);
+        item.addEventListener("keydown", focus);
+        item.addEventListener("focus", focus);
+        item.setAttribute("role", "combobox");
+        item.setAttribute("tabindex", "0");
+    });
+    function focus(event) {
+        var keyCode = event.keyCode;
+        if (keyCode === 38 || keyCode === 40) {
+            document.getElementsByClassName("select2-results__option--highlighted")[0].focus();
+        }
+        if (document.getElementsByClassName("select2-results__options").length > 0) {
+            var items = document.getElementsByClassName("select2-results__option");
+            const itemsArray = Array.from(items);
+            itemsArray.forEach(function(item) {
+                item.setAttribute("tabindex", "-1");
+            });
+        }
+        var choices = document.getElementsByClassName("select2-selection__choice");
+        const choicesArray = Array.from(choices);
+        choicesArray.forEach(function(item) {
+            item.setAttribute("tabindex", "-1");
+        });
+    }
+}

--- a/src/js/qld.bootstrap.js
+++ b/src/js/qld.bootstrap.js
@@ -10,11 +10,13 @@ import { positionQuickExit, initQuickexit } from "./../components/bs5/quickexit/
 import { displayFeedbackForm } from "./../components/bs5/footer/footer.functions";
 import { toggleSearch } from "./../components/bs5/header/header.functions";
 import { showSuggestions, submitSearchForm } from "./../components/bs5/searchInput/search.functions";
+import { handleScreenReaderAccessibility } from "./../components/bs5/select/select2.functions";
 
 window.addEventListener("scroll", positionQuickExit, true);
 window.addEventListener("resize", positionQuickExit, true);
 window.addEventListener("click", initQuickexit, true);
 window.addEventListener("keydown", initQuickexit, true);
+window.addEventListener("DOMContentLoaded", handleScreenReaderAccessibility, true);
 
 window.addEventListener("DOMContentLoaded", () => {
   (() => {


### PR DESCRIPTION
It was reported that the dropdown options on https://www.forgov.qld.gov.au/pay-benefits-and-policy/directives-policies-circulars-and-guidelines are not read by screen readers. However it happens anywhere that has select2 like:

https://www.forgov.qld.gov.au/news-events-and-consultation/find-knowledge-sharing-groups/_nocache
https://www.forgov.qld.gov.au/projects-and-initiatives/search-for-projects-and-initiatives

Handling focus and tabindex makes the screen reader to be able to read the options and also the chosen options.