### PR TITLE
fix: Search suggestions link has inline padding

### DIFF
--- a/src/components/bs5/searchInput/searchInput.scss
+++ b/src/components/bs5/searchInput/searchInput.scss
@@ -34,6 +34,9 @@
         border-bottom: solid .25rem var(--#{$prefix}site-search-suggestions-hover__border_color);
 
         .suggestions-category {
+            a {
+                padding-inline: 1rem;
+            }
             &-label {
                 padding: 0 1rem;
             }


### PR DESCRIPTION
fix: Search suggestions links have an inline padding
-> This would make sure that all link items within Search -> Suggestions have a inline padding
-> This would only ever apply if the link padding did not exist