### PR TITLE
Search suggestions link btn

### DIFF
--- a/src/components/bs5/searchInput/searchInput.scss
+++ b/src/components/bs5/searchInput/searchInput.scss
@@ -34,6 +34,9 @@
         border-bottom: solid .25rem var(--#{$prefix}site-search-suggestions-hover__border_color);
 
         .suggestions-category {
+            a {
+                padding-inline: 1rem;
+            }
             &-label {
                 padding: 0 1rem;
             }


### PR DESCRIPTION
Fix: Search suggestions link button
-> This makes all links within the suggestions-category have a inline padding of 1rem
-> This will not effect current links