### PR TITLE
fix: Inline background image style in banner component

### DIFF
--- a/src/components/bs5/banner/banner.scss
+++ b/src/components/bs5/banner/banner.scss
@@ -113,7 +113,7 @@
         right: 0;
         left: 60%;
         height: 100%;
-        background: var(--#{$prefix}banner-background-img);
+        background: var(--banner-background-img);
         background-size: cover;
         background-position: center center;
 


### PR DESCRIPTION
fix: Inline background image style in banner component
-> The issue was that a CSS custom property was missed named
-> This is now fixed within the CSS by removing the {$prefix} part of the name, as it is generated in handlebars so the {$prefix} will is not managed  