### PR TITLE
QOLOE 687 Banner background img fix

### DIFF
--- a/src/components/bs5/banner/banner.hbs
+++ b/src/components/bs5/banner/banner.hbs
@@ -24,6 +24,6 @@
         </div>
     </div>
 
-    <div class="banner-image {{image.classes}}" style="--banner-background-img:url({{image.url}})"></div>
+    <div class="banner-image {{image.classes}}" style="background-image:url({{image.url}})"></div>
 
 </div>

--- a/src/components/bs5/banner/banner.scss
+++ b/src/components/bs5/banner/banner.scss
@@ -113,7 +113,6 @@
         right: 0;
         left: 60%;
         height: 100%;
-        background: var(--#{$prefix}banner-background-img);
         background-size: cover;
         background-position: center center;
 


### PR DESCRIPTION
fix: Changed the Storybook handlebar script to add a background image
-> Removed the  background variable from the SCSS .banner-image rule, as it would be referencing a null value.