### PR TITLE
QGDS 162 bootstrap responsive typography fix

### DIFF
--- a/src/components/bs5/typography/typography.scss
+++ b/src/components/bs5/typography/typography.scss
@@ -1,66 +1,62 @@
 //Site defaults
 :root {
-	--heading-line-height: 1.5;
-	--heading-margin-bottom: 1rem;
+    --heading-line-height: 1;
 }
 
 h1,
 .h1 {
-	line-height: 1.3;
-	margin-top: 0;
-	margin-bottom: 1.5rem;
-	font-size: 2rem;
-
-	@include media-breakpoint-up(lg) {
-		font-size: 2.5rem;
-	}
-
+    line-height: $h1-line-height-mobile;
+    margin-block-start: 0;
+    margin-block-end: 1.5rem;
+    font-size: $h1-font-size-mobile;
+    @include media-breakpoint-up(lg) {
+        font-size: $h1-font-size;
+    }
 }
 
 h2,
 .h2 {
-	line-height: 1.5;
-	margin-bottom: 1.5rem;
-	font-size: 1.75rem;
-	&:not(:first-child) {
-		margin-top: 3rem;
-	}
-
-	@include media-breakpoint-up(lg) {
-		font-size: 2rem;
-	}
+    line-height: $h2-line-height-mobile;
+    margin-block-end: 1.5rem;
+    font-size: $h2-font-size-mobile;
+    &:not(:first-child) {
+        margin-block-start: 3rem;
+    }
+    @include media-breakpoint-up(lg) {
+        font-size: $h2-font-size;
+    }
 }
 
 h3,
 .h3 {
-	line-height: 1.5;
-	margin-bottom: 1.5rem;
-	font-size: 1.5rem;
-	&:not(:first-child) {
-		margin-top: 2.25rem;
-	}
+    line-height: calc(var(--heading-line-height) * 1.5);
+    margin-block-end: 1.5rem;
+    font-size: $h3-font-size;
+    &:not(:first-child) {
+        margin-block-start: 2.25rem;
+    }
 }
 
 h4,
 .h4 {
-	line-height: 1;
-	margin-bottom: 1.5rem;
-	margin-top: 2rem;
-	font-size: 1.25rem;
+    line-height: var(--heading-line-height);
+    margin-block-end: 1.5rem;
+    margin-block-start: 2rem;
+    font-size: $h4-font-size;
 }
 
 h5,
 .h5 {
-	line-height: 1;
-	margin-bottom: 1.5rem;
-	margin-top: 1.5rem;
-	font-size: 1rem;
+    line-height: var(--heading-line-height);
+    margin-block-end: 1.5rem;
+    margin-block-start: 1.5rem;
+    font-size: $h5-font-size;
 }
 
 h6,
 .h6 {
-	line-height: 1;
-	margin-bottom: 1.5rem;
-	margin-top: 1.5rem;
-	font-size: 0.87rem;
+    line-height: var(--heading-line-height);
+    margin-block-end: 1.5rem;
+    margin-block-start: 1.5rem;
+    font-size: $h6-font-size;
 }


### PR DESCRIPTION
Fix: The QGDS typography headings size are set via qld-type file