### PR TITLE
Fix: QGDS 186 Accordion minor UI fixes

### DIFF
--- a/src/components/bs5/accordion/accordion.scss
+++ b/src/components/bs5/accordion/accordion.scss
@@ -7,7 +7,6 @@ $accordion-icon-color: $qld-brand-secondary-dark;
 $accordion-icon-active-color: $qld-brand-secondary-dark;
 $accordion-button-icon: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' fill='#{$accordion-icon-color}'><path fill-rule='evenodd' d='M1.646 4.646a.5.5 0 0 1 .708 0L8 10.293l5.646-5.647a.5.5 0 0 1 .708.708l-6 6a.5.5 0 0 1-.708 0l-6-6a.5.5 0 0 1 0-.708z'/></svg>");
 $accordion-button-active-icon: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' fill='#{$accordion-icon-active-color}'><path fill-rule='evenodd' d='M1.646 4.646a.5.5 0 0 1 .708 0L8 10.293l5.646-5.647a.5.5 0 0 1 .708.708l-6 6a.5.5 0 0 1-.708 0l-6-6a.5.5 0 0 1 0-.708z'/></svg>");
-
 $accordion-icon-dark-color: $qld-brand-accent;
 $accordion-button-icon-dark: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' fill='#{$accordion-icon-dark-color}'><path fill-rule='evenodd' d='M1.646 4.646a.5.5 0 0 1 .708 0L8 10.293l5.646-5.647a.5.5 0 0 1 .708.708l-6 6a.5.5 0 0 1-.708 0l-6-6a.5.5 0 0 1 0-.708z'/></svg>");
 $accordion-button-active-icon-dark: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' fill='#{$accordion-icon-dark-color}'><path fill-rule='evenodd' d='M1.646 4.646a.5.5 0 0 1 .708 0L8 10.293l5.646-5.647a.5.5 0 0 1 .708.708l-6 6a.5.5 0 0 1-.708 0l-6-6a.5.5 0 0 1 0-.708z'/></svg>");
@@ -85,6 +84,7 @@ $accordion-button-active-icon-dark: url("data:image/svg+xml,<svg xmlns='http://w
     text-decoration-thickness: var(--#{$prefix}link-underline-thickness);
     font-weight: 600;
     line-height: 1.5rem;
+    gap: 1rem;
 
     &:hover {
       background: var(--#{$prefix}accordion-bg);
@@ -115,8 +115,10 @@ div .accordion-body {
 .accordion-toggle {
   display: flex;
   justify-content: flex-end;
-  padding: 0.5rem 0;
-  font-size: 0.75rem;
+  padding: 0;
+  padding-block-end: .5rem;
+  font-size: 0.875rem;
+  line-height: 1rem;
 
   .accordion-toggle-btn {
     background-color: transparent;
@@ -128,6 +130,10 @@ div .accordion-body {
     text-decoration: underline;
     text-underline-offset: var(--#{$prefix}link-underline-offset);
     text-decoration-thickness: var(--#{$prefix}link-underline-thickness);
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    justify-content: center;
 
     &:hover {
       text-decoration-thickness: var(--#{$prefix}link-underline-thickness-hover);
@@ -135,14 +141,9 @@ div .accordion-body {
 
     &:after {
       content: #{escape-svg($accordion-button-icon)};
-      display: inline-block;
-      width: 0.5rem;
-      height: 1rem;
-      position: absolute;
-      top: 50%;
-      margin-top: -0.5rem;
-      right: -0.5rem;
       transition: transform 0.25s ease-in;
+      height: 1rem;
+      aspect-ratio: 1 / 1;
 
       .dark &,
       .dark-alt & {


### PR DESCRIPTION
QGDS 186 Accordion minor UI fixes.

Minor fixes for all accordion colour variants:

1. Title text:
line-height: 24px/1.5rem

2. Open all/expand:
text-size: 14px/0.875rem
line-height: 16px/1rem
icon size: 16x16

3. Gap between title text and chevron icon: 16px/1rem


