### PR TITLE
Fix: Reorder of the DOM so that the video player is presented last af…

### DIFF
--- a/src/components/bs5/video/video.hbs
+++ b/src/components/bs5/video/video.hbs
@@ -8,18 +8,20 @@
 {{! By default, 'not-ready' class is added and will be removed by javascript event handler.
     When thumbnail attribute is empty / does not exist, 'empty-thumbnail' css class is added. }}
 <section class="video not-ready {{#unless thumbnail}}empty-thumbnail{{/unless}} {{videoSize}}">
+    <div class="video-description">
+        {{{ description }}}
+    </div>
+    {{#if transcriptContent}}
+        {{{ transcriptAccordion }}}
+    {{/if}}
     <div class="video-player ratio ratio-{{aspectRatio}}">
-
         <a href="#" class="video-thumbnail video-controls" title="Play Video" 
             aria-label="Watch video {{#if duration}}- duration {{formatDuration duration "long"}}{{/if}}">
-
             <div class="video-thumbnail-image" style="--thumbnail:url({{thumbnail}})"></div>
-
             <div class="video-nav">
                 <div class="video-watch">
                     <span class="icon"></span><span>Watch</span>
                 </div>
-
                 {{#if duration}}
                     <div title="Video duration" class="video-duration">
                         <span class="icon"></span><span>{{formatDuration duration}}</span>
@@ -27,32 +29,18 @@
                 {{/if}}
             </div>
         </a>
-
         <div class="video-embed ratio ratio-{{aspectRatio}}">
             {{#ifCond source '===' 'vimeo'}}
                 <iframe title="Vimeo video" class="embed-responsive-item video-vimeo" allow="autoplay; fullscreen" allowfullscreen muted="muted" src="https://player.vimeo.com/video/{{videoId}}?rel=0&autoplay={{urlParams.autoplay}}&background={{urlParams.background}}&controls={{urlParams.controls}}"></iframe>
-
             {{else ifCond source '===' 'youtube'}}
                 <iframe title="YouTube video" class="embed-responsive-item video-youtube" allow="autoplay; fullscreen" allowfullscreen src="https://www.youtube.com/embed/{{videoId}}?rel=0&autoplay={{urlParams.autoplay}}&controls={{urlParams.controls}}"></iframe>
-
             {{else ifCond source '===' 'custom'}}
                 <iframe title="Custom video" class="embed-responsive-item video-custom" allow="autoplay; fullscreen" allowfullscreen
                 src="{{videoId}}"></iframe>
-
             {{else}}
                 <p class="text-center position-absolute top-50">A video has not been provided.</p>
-
             {{/ifCond}}
         </div>
     </div>
-
-    <div class="video-description">
-        {{{ description }}}
-    </div>
-
     {{! Render the transcript content in an accordion template }}
-    {{#if transcriptContent}}
-        {{{ transcriptAccordion }}}
-    {{/if}}
-
 </section>

--- a/src/components/bs5/video/video.scss
+++ b/src/components/bs5/video/video.scss
@@ -48,7 +48,9 @@ $video-clock-icon-dark: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/20
   padding: 0px;
   border-radius: var(--#{$prefix}video-border-radius);
   box-shadow: 0px 2px 6px 2px rgba(0, 0, 0, 0.15), 0px 1px 2px rgba(0, 0, 0, 0.3);
-
+  display: grid;
+  grid-template-rows: 1fr;
+  grid-template-areas: "video" "description" "transcript";
   // Add margin top on the next element after video component
   + * {
     margin-top: 2rem;
@@ -56,7 +58,7 @@ $video-clock-icon-dark: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/20
 
   &-player {
     position: relative;
-
+    grid-area: video;
     &:focus {
       outline: 3px solid var(--#{$prefix}focus);
       outline-offset: 2px;
@@ -231,7 +233,7 @@ $video-clock-icon-dark: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/20
 
   &-description {
     padding: 0.75rem 1rem;
-
+    grid-area: description;
     p, ul, ol {
       &:last-child {
         margin-bottom: 0;
@@ -241,7 +243,7 @@ $video-clock-icon-dark: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/20
 
   .accordion {
     margin-bottom: 0;
-
+    grid-area: transcript;
     &-item {
       &,
       &:last-of-type>.accordion-header .accordion-button.collapsed {


### PR DESCRIPTION
**Requirement:** 
Description: Headings on the page are placed under each video. As such when reading down the page the incorrect video is read out immediately after the heading e.g. ‘Hyundai Kona EV Driver Induction’ and then the next video is for ‘MG ZS EV Driver Induction’.

Recommendation: Ensure that all content that should be included within a heading section, is announced AFTER the heading is announced e.g. code in the DOM before the video iframe.

**Fix:**
Reorder of the DOM so that the video player presented last after the video description and any transcript if it is available.
Used CSS grid to reorder the Video parts so that the Video Component looked like the Figma requirement.
 
This was tested using OS X -> VoiceOver accessibility feature.