### PR TITLE
Fix: QGDS 201 Promotional Panel indent-img content-right border radiu…

### DIFF
--- a/src/components/bs5/promotionalPanel/promotionalPanel.scss
+++ b/src/components/bs5/promotionalPanel/promotionalPanel.scss
@@ -253,6 +253,9 @@
             margin-inline-start: auto;
           }
         }
+        .content-panel {
+          border-radius: 0 ;
+        }
       }
     }
   }


### PR DESCRIPTION
Fix: Promotional Panel 
Issue: When in Promotional Panel uses Indent Image view. There is a left border within the content right within medium view.
This is an error and doesnt fgit with a Figma 