### PR TITLE
Fix: QGDS 178 Accessibility for mobile menu heading size

### DIFF
--- a/src/components/bs5/navbar/navbar.hbs
+++ b/src/components/bs5/navbar/navbar.hbs
@@ -7,7 +7,7 @@
 
             {{!-- Header for mobile navigation --}}
             <div class="navbar__header">
-                <h6 class="navbar__heading">Menu</h6>
+                <h3 class="navbar__heading">Menu</h3>
                 <button aria-controls="main-nav" class="navbar__toggle navbar__toggle--close" data-bs-toggle="collapse"
                     data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent"
                     aria-expanded="false" aria-label="Close menu">


### PR DESCRIPTION
Description: On a mobile device, the burger menu has a H6 heading of ‘Menu’. Withing the menu are 2 H4 sub-headings of ‘Log in to For Government’ and ‘Select your agency’. This shows incorrect hierarchy as the ‘Menu’ heading should have a higher level than any sub-headings.Recommendation: Code the ‘Menu’ heading as H3 in order to convey the correct hierarchy within the responsive menu dialog.


