### PR TITLE
Fix: QGDS 168 Added a aria-label to home link for accessibility

### DIFF
--- a/src/components/bs5/navbar/navbar.hbs
+++ b/src/components/bs5/navbar/navbar.hbs
@@ -7,7 +7,7 @@
 
             {{!-- Header for mobile navigation --}}
             <div class="navbar__header">
-                <h6 class="navbar__heading">Menu</h6>
+                <h3 class="navbar__heading">Menu</h3>
                 <button aria-controls="main-nav" class="navbar__toggle navbar__toggle--close" data-bs-toggle="collapse"
                     data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent"
                     aria-expanded="false" aria-label="Close menu">
@@ -22,7 +22,7 @@
             <ul class="navbar-nav me-auto mb-2 mb-lg-0">
                 <li class="nav-item nav-item-home">
                     <a class="nav-link {{#if metadata.options.home-active}}nav-link-home-active{{/if}}"
-                        href="{{metadata.target_url}}">
+                        href="{{metadata.target_url}}" {{#if metadata.options.home-active}}aria-label="Home"{{/if}}>
                         <svg aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" class="qld__icon">
                             <use
                                 href="{{#if metadata.options.icon-root}}{{metadata.options.icon-root}}#qld__icon__home{{/if}}">


### PR DESCRIPTION
Fix: QGDS For Accessibility a aria-label="Home" was added to the home link as a meaningful discription for when a screen reader encounted it.


Description: Icons e.g. ‘Home’ (house) can be coded as a link trigger but do not need visible text. When encountered using a screen reader something else will be read out e.g. URL for the link destination.

Recommendation: Add an accessible name to the link so that a meaningful name (purpose) can be announced when encountered using a screen reader. Suggest using aria-label=”Home”.