### PR TITLE
Fix: QGDS 170 Accessibility Fix to keep the tab focus within the mobile main nav area when visible

### DIFF
--- a/src/components/bs5/navbar/navbar.functions.js
+++ b/src/components/bs5/navbar/navbar.functions.js
@@ -42,6 +42,8 @@ export function initializeNavbar() {
   const overlay = document.getElementById('overlay');
   const body = document.body;
   const headerEl = document.querySelector('header');
+  const mainEl = document.querySelector('main');
+  const footerEl = document.querySelector('footer');
   const closeMenuButton = document.querySelector('.navbar__toggle--close');
   const openMenuButton = document.querySelector('.qld__main-nav__toggle--open');
 
@@ -90,6 +92,12 @@ export function initializeNavbar() {
       if (headerEl) {
         headerEl.setAttribute('aria-hidden', true);
       }
+      if (mainEl) {
+        mainEl.setAttribute('aria-hidden', true);
+      }
+      if (footerEl) {
+        footerEl.setAttribute('aria-hidden', true);
+      }
       if (openMenuButton) {
         openMenuButton.setAttribute('aria-label', 'Close menu');
       }
@@ -104,6 +112,12 @@ export function initializeNavbar() {
       }
       if (headerEl) {
         headerEl.setAttribute('aria-hidden', false);
+      }
+      if (mainEl) {
+        mainEl.setAttribute('aria-hidden', false);
+      }
+      if (footerEl) {
+        footerEl.setAttribute('aria-hidden', false);
       }
     });
   }


### PR DESCRIPTION
Fix: Accessibility issue of keeping the tab focus within the main nav area when the main nav is visible.

Description: On a mobile device, when the burger menu is opened the screen reader can read through the items in the menu, however after the last item e.g. ‘Log in’ toggle the read continues onto the page underneath.

Recommendation: Ensure that the screen reader focus remains in the dialog until expressly dismissed using the ‘Close’ button e.g. after the last item in the list the read loops back to the first item in the dialog.

Solution: Use the current aria-hidden="true" used within navbar.functions.js to hide the main and footer tags.
This should work the same way as the current header tag works when mobile main nav is visible.