### PR TITLE
disabled chromatic snapshotting for content footer story for default …

### DIFF
--- a/src/components/bs5/contentFooter/contentFooter.stories.js
+++ b/src/components/bs5/contentFooter/contentFooter.stories.js
@@ -46,6 +46,9 @@ export const Default = {
 export const DefaultEmpty = {
   args: {
   },
+  parameters: {
+    chromatic: { disableSnapshot: true },
+  },
   decorators:[Story => {
     return `
           ${Story()}


### PR DESCRIPTION
For the Content Footer story, the chromatic snapshots can be disabled to reduce the snapshots taken
<img width="1884" height="534" alt="image" src="https://github.com/user-attachments/assets/e845b5c9-53e8-4763-9793-5dd7ae810dff" />
