### PR TITLE
Qgds 250 bug quick exit is not sticky at the top of the page in desktop view

### DIFF
--- a/src/components/bs5/quickexit/quickexit.functions.js
+++ b/src/components/bs5/quickexit/quickexit.functions.js
@@ -1,20 +1,3 @@
-/*export function positionQuickExit() {
-  let quickexitInstances = document.getElementsByClassName("qld-quick-exit");
-  if (quickexitInstances.length > 0) {
-    const el = document.getElementsByClassName("qld-quick-exit")[0];
-    if (document.documentElement.clientWidth > 992) {
-       if (window.pageYOffset > 200) {
-        el.setAttribute("style", "position: 'fixed', top: '0px'");
-      }
-      if (window.pageYOffset < 200) {
-        el.setAttribute("style", "position: 'sticky', top: '0px'");
-      } 
-    } else {
-      el.setAttribute("style", "position: 'fixed', top: 'auto'");
-    }
-  }
-}*/
-
 export function initQuickexit() {
   var quickExitElement = document.getElementsByClassName("qld-quick-exit");
   var quickExitButton = document.querySelector(".qld-quick-exit-button");

--- a/src/components/bs5/quickexit/quickexit.functions.js
+++ b/src/components/bs5/quickexit/quickexit.functions.js
@@ -1,19 +1,19 @@
-export function positionQuickExit() {
+/*export function positionQuickExit() {
   let quickexitInstances = document.getElementsByClassName("qld-quick-exit");
   if (quickexitInstances.length > 0) {
     const el = document.getElementsByClassName("qld-quick-exit")[0];
     if (document.documentElement.clientWidth > 992) {
-      /* if (window.pageYOffset > 200) {
+       if (window.pageYOffset > 200) {
         el.setAttribute("style", "position: 'fixed', top: '0px'");
       }
       if (window.pageYOffset < 200) {
         el.setAttribute("style", "position: 'sticky', top: '0px'");
-      } */
+      } 
     } else {
       el.setAttribute("style", "position: 'fixed', top: 'auto'");
     }
   }
-}
+}*/
 
 export function initQuickexit() {
   var quickExitElement = document.getElementsByClassName("qld-quick-exit");

--- a/src/components/bs5/quickexit/quickexit.functions.js
+++ b/src/components/bs5/quickexit/quickexit.functions.js
@@ -1,7 +1,7 @@
 export function positionQuickExit() {
-  let quickexitInstances = document.getElementsByClassName('qld-quick-exit');
+  let quickexitInstances = document.getElementsByClassName("qld-quick-exit");
   if (quickexitInstances.length > 0) {
-    const el = document.getElementsByClassName('qld-quick-exit')[0];
+    const el = document.getElementsByClassName("qld-quick-exit")[0];
     if (document.documentElement.clientWidth > 992) {
       if (window.pageYOffset > 200) {
         el.setAttribute("style", "position: 'fixed', top: '0px'");
@@ -16,34 +16,38 @@ export function positionQuickExit() {
 }
 
 export function initQuickexit() {
-  var quickExitElement = document.getElementsByClassName('qld-quick-exit');
-  var quickExitButton = document.querySelector('.qld-quick-exit-button');
+  var quickExitElement = document.getElementsByClassName("qld-quick-exit");
+  var quickExitButton = document.querySelector(".qld-quick-exit-button");
 
-  if (quickExitElement.length > 0 && typeof (quickExitButton) !== 'undefined' && quickExitButton != null) {
+  if (
+    quickExitElement.length > 0 &&
+    typeof quickExitButton !== "undefined" &&
+    quickExitButton != null
+  ) {
     onbtnClick();
     onKeyDown();
   }
 }
 /**
-* onbtnClick -> clicking quick exit button a page
-* @return {undefined}
-**/
+ * onbtnClick -> clicking quick exit button a page
+ * @return {undefined}
+ **/
 function onbtnClick() {
-  const escapeSite = 'https://www.google.com.au/';
-  var quickExitButton = document.querySelector('.qld-quick-exit-button');
+  const escapeSite = "https://www.google.com.au/";
+  var quickExitButton = document.querySelector(".qld-quick-exit-button");
   quickExitButton.onclick = function () {
     return quickExit(escapeSite);
-  }
+  };
 }
 
 /**
-* onKeyDown -> escape keydown event
-* @return {undefined}
-**/
+ * onKeyDown -> escape keydown event
+ * @return {undefined}
+ **/
 function onKeyDown() {
-  const escapeSite = 'https://www.google.com.au/';
+  const escapeSite = "https://www.google.com.au/";
   // add hotkey trigger
-  document.addEventListener('keydown', function (e) {
+  document.addEventListener("keydown", function (e) {
     if (e.keyCode === 27) {
       quickExit(escapeSite);
       if (e) {
@@ -58,18 +62,18 @@ function onKeyDown() {
 }
 
 /**
-* quickExit function redirects a user on click and Esc key down
-* @param {string} site - site to replace on initiating the 'quick exit' ('Esc' key or clicking 'Close this site' button) function
-* @return {undefined}
-**/
+ * quickExit function redirects a user on click and Esc key down
+ * @param {string} site - site to replace on initiating the 'quick exit' ('Esc' key or clicking 'Close this site' button) function
+ * @return {undefined}
+ **/
 function quickExit(site) {
   // then redirect to a non-sensitive site
-  window.open(site, '_blank');
+  window.open(site, "_blank");
   window.location.replace(site);
   // remove as much info from URL as possible
   if (window.history) {
     try {
-      window.history.replaceState({}, '', '/');
+      window.history.replaceState({}, "", "/");
     } catch (e) {
       e.printStackTrace();
     }

--- a/src/components/bs5/quickexit/quickexit.functions.js
+++ b/src/components/bs5/quickexit/quickexit.functions.js
@@ -3,12 +3,12 @@ export function positionQuickExit() {
   if (quickexitInstances.length > 0) {
     const el = document.getElementsByClassName("qld-quick-exit")[0];
     if (document.documentElement.clientWidth > 992) {
-      if (window.pageYOffset > 200) {
+      /* if (window.pageYOffset > 200) {
         el.setAttribute("style", "position: 'fixed', top: '0px'");
       }
       if (window.pageYOffset < 200) {
         el.setAttribute("style", "position: 'sticky', top: '0px'");
-      }
+      } */
     } else {
       el.setAttribute("style", "position: 'fixed', top: 'auto'");
     }

--- a/src/components/bs5/quickexit/quickexit.scss
+++ b/src/components/bs5/quickexit/quickexit.scss
@@ -263,3 +263,10 @@
     }
   }
 }
+
+body:has(.qld-quick-exit) {
+  html,
+  body {
+    height: auto;
+  }
+}

--- a/src/components/bs5/quickexit/quickexit.scss
+++ b/src/components/bs5/quickexit/quickexit.scss
@@ -265,8 +265,5 @@
 }
 
 body:has(.qld-quick-exit) {
-  html,
-  body {
-    height: auto;
-  }
+  height: auto;
 }

--- a/src/js/qld.bootstrap.js
+++ b/src/js/qld.bootstrap.js
@@ -21,8 +21,6 @@ import { initTabsScroll } from "./../components/bs5/tabs/tabs.functions";
 import { initGlobalAlerts } from "./../components/bs5/globalAlert/globalAlert.function";
 import { validateSkipLinks } from "./../components/bs5/skiplinks/skipLinks.functions";
 
-//window.addEventListener("scroll", positionQuickExit, true);
-//window.addEventListener("resize", positionQuickExit, true);
 window.addEventListener("click", initQuickexit, true);
 window.addEventListener("keydown", initQuickexit, true);
 
@@ -148,8 +146,6 @@ window.addEventListener("DOMContentLoaded", () => {
     initBreadcrumb();
 
     // Quick exit
-    //window.addEventListener("scroll", positionQuickExit, true);
-    //window.addEventListener("resize", positionQuickExit, true);
     window.addEventListener("click", initQuickexit, true);
     window.addEventListener("keydown", initQuickexit, true);
     initQuickexit();

--- a/src/js/qld.bootstrap.js
+++ b/src/js/qld.bootstrap.js
@@ -9,10 +9,7 @@ import {
 } from "./../components/bs5/video/video.functions";
 import { initializeNavbar } from "./../components/bs5/navbar/navbar.functions";
 import { initBreadcrumb } from "./../components/bs5/breadcrumbs/breadcrumbs.functions";
-import {
-  positionQuickExit,
-  initQuickexit,
-} from "./../components/bs5/quickexit/quickexit.functions";
+import { initQuickexit } from "./../components/bs5/quickexit/quickexit.functions";
 //import { displayFeedbackForm } from "./../components/bs5/footer/footer.functions";
 import { toggleSearch } from "./../components/bs5/header/header.functions";
 import {
@@ -24,8 +21,8 @@ import { initTabsScroll } from "./../components/bs5/tabs/tabs.functions";
 import { initGlobalAlerts } from "./../components/bs5/globalAlert/globalAlert.function";
 import { validateSkipLinks } from "./../components/bs5/skiplinks/skipLinks.functions";
 
-window.addEventListener("scroll", positionQuickExit, true);
-window.addEventListener("resize", positionQuickExit, true);
+//window.addEventListener("scroll", positionQuickExit, true);
+//window.addEventListener("resize", positionQuickExit, true);
 window.addEventListener("click", initQuickexit, true);
 window.addEventListener("keydown", initQuickexit, true);
 
@@ -151,12 +148,11 @@ window.addEventListener("DOMContentLoaded", () => {
     initBreadcrumb();
 
     // Quick exit
-    window.addEventListener("scroll", positionQuickExit, true);
-    window.addEventListener("resize", positionQuickExit, true);
+    //window.addEventListener("scroll", positionQuickExit, true);
+    //window.addEventListener("resize", positionQuickExit, true);
     window.addEventListener("click", initQuickexit, true);
     window.addEventListener("keydown", initQuickexit, true);
     initQuickexit();
-    positionQuickExit();
 
     // Accordion
     let accordionToggleButton = document.querySelectorAll(


### PR DESCRIPTION
Quick exit made sticky at the top of the page in desktop view even when scrolled down to lower most scroll position
The fix was to make body height auto when we have quick exit component inside the body element.
Apart from that cleaned up unwanted position fixing from JavaScript as it is no more required