### PR TITLE
fix: correct text decoration style to underline to match figma

### DIFF
--- a/src/components/bs5/inpagenav/inpagenav.scss
+++ b/src/components/bs5/inpagenav/inpagenav.scss
@@ -46,6 +46,7 @@
       padding-bottom: var(--#{$prefix}inpage-nav-link-padding-y);
       padding-left: var(--#{$prefix}inpage-nav-title-padding-left);
       color: var(--#{$prefix}nav-link-color);
+      text-decoration-line: underline;
     }
 
     &:first-child .nav-link {


### PR DESCRIPTION
Correct text decoration to underline as in figma