### PR TITLE
fix: Icon rotation direction

### DIFF
--- a/src/components/bs5/navbar/navbar.scss
+++ b/src/components/bs5/navbar/navbar.scss
@@ -59,7 +59,7 @@
             button.nav-link {
               background-color: var(--dropdown-show-btn-bg);
               &::after {
-                transform: rotate(180deg);
+                transform: rotate(-180deg);
                 transition: transform var(--animation-time) ease-in;
               }
             }
@@ -506,7 +506,7 @@
     }
     &.show {
       &:after {
-        transform: rotate(180deg);
+        transform: rotate(-180deg);
         transition: transform var(--animation-time) ease-in;
       }
     }


### PR DESCRIPTION
Fix: After talking to the designers, we have agreed that the icons would animate away from the labels.
This means that the NavBar icons now need to rotate -180deg