### PR TITLE
fix(header): add mobile border for v2.0.5 compatibility

### DIFF
--- a/src/components/bs5/header/header.scss
+++ b/src/components/bs5/header/header.scss
@@ -293,6 +293,14 @@
     position: relative;
     color: var(--#{$prefix}header-color-text);
     background: var(--#{$prefix}header-color-bg);
+
+    // Patch for v2.0.5. Redundant after header QGDS-266 is merged
+    border-bottom: 0.25rem solid var(--qld-light-accent);
+
+    @include media-breakpoint-up(lg) {
+      border-bottom: none;
+    }
+    // End patch for v2.0.5
   }
 
   &-brand {


### PR DESCRIPTION
- Header: Adds temporary 0.25rem border-bottom on mobile/tablet viewports.  This patch will be removed when header QGDS-266 is merged.