### PR TITLE
QGDS-369 Fix: Alert children vertical spaing issue

### DIFF
--- a/src/components/bs5/inpageAlert/inpageAlert.scss
+++ b/src/components/bs5/inpageAlert/inpageAlert.scss
@@ -30,12 +30,11 @@
   ul,
   ol {
     line-height: 1.5;
-
-    &:last-of-type {
-      margin-bottom: 0;
-    }
   }
 
+  &> :last-child {
+    margin-bottom: 0;
+  }
   // Close button for dismissible alerts
   .btn-close {
     position: absolute;


### PR DESCRIPTION
Fix: The :last-of-type margin-bottom:0 causing the spacing issue. 