### PR TITLE
QGDS-321 Fix: Button Hover underline thickness

### DIFF
--- a/src/components/bs5/button/button.scss
+++ b/src/components/bs5/button/button.scss
@@ -170,6 +170,7 @@ a.btn,
     color: var(--#{$prefix}btn-color);
     text-decoration: underline;
     text-decoration-color: inherit;
+    text-decoration-thickness: var(--qld-link-underline-thickness-hover, 2px);
     text-underline-offset: 0.3em;
   }
 


### PR DESCRIPTION
- Applies correct 2px text underline thickness on buttons (hover state)