### PR TITLE
Hotfix - zindex for quick-exit bar

### DIFF
--- a/src/components/bs5/navbar/navbar.scss
+++ b/src/components/bs5/navbar/navbar.scss
@@ -561,7 +561,7 @@
     grid-template-columns: repeat(3, 1fr);
     column-gap: 2rem;
     row-gap: 0;
-    z-index: 10;
+    z-index: 999;
     border-width: 0;
     @include media-breakpoint-up(xl) {
       column-gap: 4rem;

--- a/src/components/bs5/quickexit/quickexit.scss
+++ b/src/components/bs5/quickexit/quickexit.scss
@@ -166,7 +166,7 @@
     position: -webkit-sticky;
     position: sticky;
     inset-block-start: 0;
-    z-index: 999;
+    z-index: 500;
     padding-block: 20px;
     padding-inline: 40px;
     .container {


### PR DESCRIPTION
- This PR fixes a z-index issue causing menu and suggestions containers to hide behind the quick-exit bar  