### PR TITLE
Feature (css): Adds browserlist, postcss and autoprefix

### DIFF
--- a/.browserslistrc
+++ b/.browserslistrc
@@ -1,0 +1,17 @@
+# Browserslist configuration
+
+# https://github.com/browserslist/browserslist
+
+# Includes QLD Government browserlist
+
+# https://www.forgov.qld.gov.au/communication-and-publishing/website-standards-guidelines-and-templates/browser-support/browser-support-list
+
+chrome >= 102
+safari >= 16.1
+edge >= 102
+firefox >= 91
+samsung >= 16
+ios_saf >= 15.6
+op_mob >= 73
+opera >= 99
+android >= 4.4

--- a/esbuild.js
+++ b/esbuild.js
@@ -16,6 +16,8 @@ import { createOverrideThemeScssEntry } from "./.esbuild/helpers/scssOverrideThe
 //Open source ESBUILD PLUGINS
 import { sassPlugin } from "esbuild-sass-plugin";
 import handlebarsPlugin from "esbuild-plugin-handlebars";
+import postcss from "postcss";
+import autoprefixer from "autoprefixer";
 
 //Command line arguments are available via argv object
 import minimist from "minimist";
@@ -27,7 +29,7 @@ const versionString = `${process.env.npm_package_name} - v${process.env.npm_pack
 // https://esbuild.github.io/getting-started/#build-scripts
 const buildConfig = {
   bundle: true,
-  minify: true,
+  minify: argv.minify !== "false", //true, unless flagged: 'npm run build -- --minify=false'
   sourcemap: true,
   target: ["es6"],
   logLevel: "info",
@@ -95,6 +97,13 @@ const buildConfig = {
       indentType: "space",
       indentWidth: 2,
       loadPaths: ["./node_modules"],
+      async transform(source, resolveDir) {
+        const result = await postcss([autoprefixer({ remove: false })]).process(
+          source,
+          { from: undefined },
+        );
+        return result.css;
+      },
     }),
     QDGSbuildLog(),
   ],
@@ -103,7 +112,7 @@ const buildConfig = {
 const buildNodeConfig = {
   loader: buildConfig.loader,
   bundle: true,
-  minify: false,
+  minify: argv.minify !== "false", //true, unless flagged: 'npm run build -- --minify=false'
   sourcemap: true,
   minifyIdentifiers: false,
   logLevel: buildConfig.logLevel,

--- a/package-lock.json
+++ b/package-lock.json
@@ -3924,9 +3924,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001706",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001706.tgz",
-      "integrity": "sha512-3ZczoTApMAZwPKYWmwVbQMFpXBDds3/0VciVoUwPUbldlYyVLmRVuRs/PcUZtHpbLRpzzDvrvnFuREsGt6lUug==",
+      "version": "1.0.30001761",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001761.tgz",
+      "integrity": "sha512-JF9ptu1vP2coz98+5051jZ4PwQgd2ni8A+gYSN7EA7dPKIMf0pDlSUxhdmVOaV3/fYK5uWBkgSXJaRLr4+3A6g==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
QGDS-571: This PR updates our build pipeline to support the QLD Gov mandatory browser list.

**Fix:** 
Resolves icon rendering issues in Chrome 102 by adding -webkit-mask-image prefixes via Autoprefixer.

**Feature:** 
Added postcss support to the SASS plugin.
Added a toggle to disable CSS minification for troubleshooting.

**Config:** 
Targeting a baseline including Chrome 102, Safari 16.1, and Firefox 91