### PR TITLE
QGDS-517 enable configuration for mobile nav items to be open by default

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,5 +2,5 @@
   "accessibility.voice.keywordActivation": "off",
   "accessibility.voice.speechTimeout": 800,
   "editor.formatOnSave": true,
-  "editor.defaultFormatter": "esbenp.prettier-vscode"
+  "editor.defaultFormatter": "prettier.prettier-vscode"
 }

--- a/src/components/bs5/navbar/navbar.data.json
+++ b/src/components/bs5/navbar/navbar.data.json
@@ -24,6 +24,7 @@
       "currentPage": false,
       "hideLabel": false,
       "target": "_blank",
+      "isExpandedOnMobile": true,
       "dropdownOptions": {
         "hasNoLink": false,
         "alternativeText": "",

--- a/src/components/bs5/navbar/navbar.functions.js
+++ b/src/components/bs5/navbar/navbar.functions.js
@@ -1,6 +1,5 @@
 import { createFocusTrap } from "../../../js/utils.js";
 import { breakpoints } from "../../../js/constants.js";
-import { getFocusableElements } from "../../../js/utils.js";
 
 const getIsMobile = () => window.innerWidth < breakpoints.lg;
 
@@ -9,6 +8,7 @@ export function initializeNavbar() {
   const overlay = document.getElementById("overlay");
   const burgerBtn = document.getElementById("burgerBtn");
   const burgerCloseBtn = document.getElementById("burgerCloseBtn");
+  let wasMobile = getIsMobile();
 
   /** @type {HTMLElement[]} */
   let inertTargets = [];
@@ -94,34 +94,54 @@ export function initializeNavbar() {
     closeNavbar();
   });
 
-  const resetNavbarState = () => {
-    const isMobile = getIsMobile();
+  const resetNavbarState = (isMobile) => {
     const dropdownToggles = navbar?.querySelectorAll(
       "a.dropdown-toggle, a.no-dropdown-toggle",
     );
 
-    // Toggle dropdown functionality based on screen size
-    dropdownToggles?.forEach((toggle) => {
-      if (isMobile) {
+    if (isMobile) {
+      // disable navlinks as toggles
+      dropdownToggles?.forEach((toggle) => {
         // Skip toggle items with hasNoLink class
         if (toggle.classList.contains("hasNoLink")) {
           return;
         }
         toggle.classList.replace("dropdown-toggle", "no-dropdown-toggle");
         toggle.removeAttribute("data-bs-toggle");
-      } else {
+      });
+
+      // Expand any dropdowns set to expand on mobile
+      navbar
+        ?.querySelectorAll('[data-is-expanded-on-mobile="true"]')
+        .forEach((item) => {
+          item
+            .querySelectorAll(".dropdown-toggle, .dropdown-menu")
+            .forEach((item) => {
+              item.classList.add("show");
+            });
+        });
+    } else {
+      // reenable navlinks as toggle
+      dropdownToggles?.forEach((toggle) => {
         toggle.classList.replace("no-dropdown-toggle", "dropdown-toggle");
         toggle.setAttribute("data-bs-toggle", "dropdown");
-      }
-    });
+      });
 
-    if (!isMobile) {
+      // Collapse any dropdowns set to expand on mobile
+      navbar
+        ?.querySelectorAll('[data-is-expanded-on-mobile="true"]')
+        .forEach((item) => {
+          item
+            .querySelectorAll(".dropdown-toggle, .dropdown-menu")
+            .forEach((item) => {
+              item.classList.remove("show");
+            });
+        });
+
+      // close the navbar
       closeNavbar();
     }
   };
-
-  window.addEventListener("resize", resetNavbarState);
-  resetNavbarState();
 
   //All associated side effects of navbar collapse beginning belong here
   navbar?.addEventListener("hide.bs.collapse", () => {
@@ -160,4 +180,14 @@ export function initializeNavbar() {
       }, 0);
     }
   });
+
+  window.addEventListener("resize", () => {
+    const isMobile = getIsMobile();
+    if (wasMobile !== isMobile) {
+      wasMobile = isMobile;
+      resetNavbarState(isMobile);
+    }
+  });
+
+  resetNavbarState(wasMobile);
 }

--- a/src/components/bs5/navbar/navbar.hbs
+++ b/src/components/bs5/navbar/navbar.hbs
@@ -12,7 +12,7 @@
                 <ul class="navbar-nav">
                     {{#each navigation}}
                         {{#if navigationItems}}
-                            <li class="nav-item dropdown{{#if alternativeColor}} alt{{/if}}{{#if mobileOnly}} mobile-only{{/if}}"> 
+                            <li class="nav-item dropdown{{#if alternativeColor}} alt{{/if}}{{#if mobileOnly}} mobile-only{{/if}}"{{#if isExpandedOnMobile}} data-is-expanded-on-mobile="true"{{/if}}>
                                 <a class="nav-link{{#unless ../metadata.verticalOrientation}} dropdown-toggle{{/unless}}{{#if currentPage}} active{{/if}}{{#if dropdownOptions.hasNoLink}} hasNoLink{{/if}}" {{#if currentPage}}aria-current="page"{{/if}}{{#if dropdownOptions.hasNoLink}} href="#"{{else}} href="{{url}}"{{/if}}{{#if target}} target="{{target}}"{{/if}}{{#ifCond target '==' '_blank'}} rel="noopener noreferrer"{{/ifCond}} role="button" data-bs-toggle="dropdown"
                             aria-expanded="false">
                                 {{#if iconName}}


### PR DESCRIPTION
This addresses the following ticket:
https://www.jira.services.qld.gov.au/browse/QGDS-517

What this PR does:
- Adds a new option to navbar items "isExpandedOnMobile". If set to true, the dropdown should display as expanded when on mobile.

Note: There is some flaky behaviour in Storybook especially when testing Navbar component. Switching between pages does not always trigger the script to reset the mobile state. Somewhat better results testing the navbar on Layout or header components