### PR TITLE
Fix (Link Columns): LI layout patch required for older browsers

### DIFF
--- a/src/components/bs5/linkColumns/linkColumns.scss
+++ b/src/components/bs5/linkColumns/linkColumns.scss
@@ -22,7 +22,7 @@
     max-width: var(--max-column-width);
   }
   ul {
-    width: 100%;
+    // width: 100%;
     display: grid;
     gap: 0 1rem;
   }
@@ -83,10 +83,8 @@
     //Reset the line height too to override styles from .qld-content-body li
     line-height: 1.5rem;
 
-    /* 
-    This prevents LI's from breaking across columns 
-    Legacy support for older WebKit browsers (=< chrome 104)
-    */
+    // This prevents LI's from breaking across columns
+    // Legacy support for older WebKit browsers (=< chrome 104)
     break-inside: avoid-column;
     -webkit-column-break-inside: avoid;
 

--- a/src/components/bs5/linkColumns/linkColumns.scss
+++ b/src/components/bs5/linkColumns/linkColumns.scss
@@ -3,7 +3,7 @@
   --color-border: var(--#{$prefix}neutral-lighter);
 
   background-color: var(--#{$prefix}body-bg);
-  
+
   &.light {
     --color-border: var(--#{$prefix}light-border);
   }
@@ -22,7 +22,7 @@
     max-width: var(--max-column-width);
   }
   ul {
-    width: 100%;  
+    width: 100%;
     display: grid;
     gap: 0 1rem;
   }
@@ -31,17 +31,17 @@
   }
   .col-2 {
     grid-template-columns: repeat(2, 1fr);
-    @include media-breakpoint-down(md) { 
+    @include media-breakpoint-down(md) {
       grid-template-columns: repeat(1, 1fr);
     }
   }
   .col-3 {
     grid-template-columns: repeat(3, 1fr);
     @include media-breakpoint-down(lg) {
-        grid-template-columns: repeat(2, 1fr);
+      grid-template-columns: repeat(2, 1fr);
     }
     @include media-breakpoint-down(md) {
-        grid-template-columns: repeat(1, 1fr);
+      grid-template-columns: repeat(1, 1fr);
     }
   }
   .col-vert-1 {
@@ -64,9 +64,9 @@
     column-count: 3;
     column-gap: 2rem;
     @include media-breakpoint-down(lg) {
-        column-count: 2;
-        column-gap: 1.5rem;
-    }    
+      column-count: 2;
+      column-gap: 1.5rem;
+    }
     @include media-breakpoint-down(md) {
       column-count: 1;
     }
@@ -82,11 +82,21 @@
     margin-block: 0;
     //Reset the line height too to override styles from .qld-content-body li
     line-height: 1.5rem;
+
+    /* 
+    This prevents LI's from breaking across columns 
+    Legacy support for older WebKit browsers (=< chrome 104)
+    */
+    break-inside: avoid-column;
+    -webkit-column-break-inside: avoid;
+
     .nav-link {
       text-decoration: underline;
       text-decoration-color: transparent;
       text-decoration-thickness: 0;
-      transition: text-decoration-thickness 0.2s ease, text-decoration-color 0.2s ease;
+      transition:
+        text-decoration-thickness 0.2s ease,
+        text-decoration-color 0.2s ease;
       display: flex;
       align-items: center;
       flex: 1;
@@ -105,22 +115,28 @@
         mask-repeat: no-repeat;
         mask-position: right center;
         background-color: var(--#{$prefix}action-icon-color);
-        transition: margin-inline-end 0.2s ease, width 0.2s ease;
+        transition:
+          margin-inline-end 0.2s ease,
+          width 0.2s ease;
       }
       &:hover {
         text-decoration-color: var(--#{$prefix}link-color);
         text-decoration-thickness: 2px;
-        transition: text-decoration-thickness 0.2s ease, text-decoration-color 0.2s ease;
+        transition:
+          text-decoration-thickness 0.2s ease,
+          text-decoration-color 0.2s ease;
         &::after {
           background-color: var(--#{$prefix}action-icon-hover-color);
           margin-inline-end: 0rem;
           width: 2.5rem;
-          transition: margin-inline-end 0.2s ease, width 0.2s ease;
+          transition:
+            margin-inline-end 0.2s ease,
+            width 0.2s ease;
         }
       }
     }
   }
-  .all-link{
+  .all-link {
     grid-column: 1/-1;
     max-width: 100%;
     border-block-end: none;


### PR DESCRIPTION
To prevent LI elements from splitting across columns, we need to explicitly tell order browsers (Chrome/Edge < 104) to treat the list item as an atomic unit that cannot be broken.

This PR adds break inside rules to fix this layout bug on Link Columns components.

<img width="1746" height="634" alt="image" src="https://github.com/user-attachments/assets/6007b3a0-e194-481e-b24d-8442d7e0b070" />

<img width="2232" height="720" alt="image" src="https://github.com/user-attachments/assets/e23ccbc8-4275-4098-8d09-919fd10c275f" />
