### PR TITLE
QGDS 574 fix contnet width without hero img

### DIFF
--- a/src/components/bs5/banner/banner.scss
+++ b/src/components/bs5/banner/banner.scss
@@ -223,7 +223,7 @@
       }
     }
 
-    &.text-full-width:not(:has(.banner-image)) {
+    &.is-full-width:not(:has(.banner-image)) {
       @include media-breakpoint-up(md) {
         .banner-content {
           grid-column: 1 / -1;

--- a/src/components/bs5/banner/banner.scss
+++ b/src/components/bs5/banner/banner.scss
@@ -223,7 +223,7 @@
       }
     }
 
-    &:not(:has(.banner-image)) {
+    &.text-full-width:not(:has(.banner-image)) {
       @include media-breakpoint-up(md) {
         .banner-content {
           grid-column: 1 / -1;

--- a/src/components/bs5/banner/banner.scss
+++ b/src/components/bs5/banner/banner.scss
@@ -222,6 +222,17 @@
         grid-row: 1 / span 2; // Spans rows 1 and 2
       }
     }
+
+    &:not(:has(.banner-image)) {
+      @include media-breakpoint-up(md) {
+        .banner-content {
+          grid-column: 1 / -1;
+          .banner-abstract {
+            max-width: none;
+          }
+        }
+      }
+    }
   }
 }
 


### PR DESCRIPTION
Banner content in cases without a hero image is not full-width in smaller screens in storybook: 
It is due to below code in banner.scss:

@media (min-width: 700px) {
    .qld-banner-grid .banner-inner .banner-content {
        grid-column: 1 / span 7;
        grid-row: 2 / span 1;
    }
}

This is while in Design System website, banner content goes full-width when there is no hero image