### PR TITLE
QGDS 574 Banner without hero img for mobile

### DIFF
--- a/src/components/bs5/banner/banner.scss
+++ b/src/components/bs5/banner/banner.scss
@@ -224,7 +224,7 @@
     }
 
     &.is-full-width:not(:has(.banner-image)) {
-      @include media-breakpoint-up(md) {
+      @include media-breakpoint-down(md) {
         .banner-content {
           grid-column: 1 / -1;
           .banner-abstract {

--- a/src/components/bs5/banner/banner.scss
+++ b/src/components/bs5/banner/banner.scss
@@ -224,7 +224,7 @@
     }
 
     &.is-full-width:not(:has(.banner-image)) {
-      @include media-breakpoint-down(md) {
+      @include media-breakpoint-down(lg) {
         .banner-content {
           grid-column: 1 / -1;
           .banner-abstract {


### PR DESCRIPTION
Fix: Changed the media breakpoint to  media-breakpoint-down(lg) to be applicable for iPad and mobile views