### PR TITLE
QGDS-588 using grid layout collapsed the ul width

### DIFF
--- a/src/components/bs5/linkColumns/linkColumns.scss
+++ b/src/components/bs5/linkColumns/linkColumns.scss
@@ -22,7 +22,7 @@
     max-width: var(--max-column-width);
   }
   ul {
-    // width: 100%;
+    width: 100%;
     display: grid;
     gap: 0 1rem;
   }


### PR DESCRIPTION
Fix: The Link Columns layout width collapsed when using the grid layout.
This makes the list items display horizontally, unlike its default layout that makes the list items display vertically.

When the list items used the grid layout, the link items collapsed to its minimum width. Making the overall Link Columns display at a reduced width, instead of the full width of its parent container.