### PR TITLE
QGDS-608 changed the tag-list gap width

### DIFF
--- a/src/components/bs5/card/card.scss
+++ b/src/components/bs5/card/card.scss
@@ -426,7 +426,7 @@
     .tag-list {
       margin: 0;
       padding: 0;
-      gap: 1rem;
+      gap: 0.5rem;
       display: flex;
       flex-wrap: wrap;
       .tag-item {


### PR DESCRIPTION
Fix: change Card footer tag list gap to 0.5rem.