### PR TITLE
QGDS-579 fix for Select with a long placeholder text

### DIFF
--- a/src/components/bs5/formcheck/formcheck.scss
+++ b/src/components/bs5/formcheck/formcheck.scss
@@ -271,6 +271,11 @@ $form-check-inline-margin-end: 1rem;
   }
 }
 
+.form-select {
+  text-overflow: ellipsis;
+  padding-inline-end: 42px;
+}
+
 .form-check {
   display: flex;
   align-items: center;


### PR DESCRIPTION
Fix: The HTML form Select object had an issue with long placeholder text.
Causing the text to appear behide the dropdown icon. 
This caused a visual mess.

This solution should fix the issue.