### PR TITLE
chore(eslint): Remove redundant plugin esbuild-plugin-eslint

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -30,7 +30,6 @@ updates:
         patterns:
           - "eslint*"
           - "@stylistic/eslint-plugin-js"
-          - "esbuild-plugin-eslint"
       esbuild:
         patterns:
           - "esbuild*"

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,6 @@
         "chromatic": "^15.0.0",
         "esbuild": "0.27.3",
         "esbuild-plugin-copy": "^2.1.1",
-        "esbuild-plugin-eslint": "^0.3.12",
         "esbuild-plugin-handlebars": "1.0.3",
         "esbuild-sass-plugin": "3.6.0",
         "eslint": "9.39.2",
@@ -1934,6 +1933,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -1955,6 +1955,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -1976,6 +1977,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -1997,6 +1999,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -2018,6 +2021,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -2039,6 +2043,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -2060,6 +2065,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -2081,6 +2087,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -2102,6 +2109,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -2123,6 +2131,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -2144,6 +2153,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -2165,6 +2175,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -2186,6 +2197,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -5028,20 +5040,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/esbuild-plugin-eslint": {
-      "version": "0.3.12",
-      "resolved": "https://registry.npmjs.org/esbuild-plugin-eslint/-/esbuild-plugin-eslint-0.3.12.tgz",
-      "integrity": "sha512-n37Nn6vmh2tdGMnm6GZebiYJDrqERAReyvLFwdCWCw15ZvAu251i6cIeJWoVB8AiS+j3N97gylvf58ysIwii4g==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "esbuild": ">=0.20",
-        "eslint": "^8 || ^9"
       }
     },
     "node_modules/esbuild-plugin-handlebars": {

--- a/package.json
+++ b/package.json
@@ -73,7 +73,6 @@
     "chromatic": "^15.0.0",
     "esbuild": "0.27.3",
     "esbuild-plugin-copy": "^2.1.1",
-    "esbuild-plugin-eslint": "^0.3.12",
     "esbuild-plugin-handlebars": "1.0.3",
     "esbuild-sass-plugin": "3.6.0",
     "eslint": "9.39.2",


### PR DESCRIPTION
This PR removes a redundant plugin esbuild-plugin-eslint.

esbuild-plugin-eslint is not maintained and is not used by this project.
