### PR TITLE
Fix for code scanning alert no. 14: DOM text reinterpreted as HTML

### DIFF
--- a/src/components/bs5/searchInput/search.functions.js
+++ b/src/components/bs5/searchInput/search.functions.js
@@ -196,6 +196,14 @@ export async function showSuggestions(value = "", isDefault = false, form) {
           dynamicSuggestionsContainer.getAttribute("data-view-more");
 
         // Build the services HTML safely
+        const escapeHtmlAttr = (str) =>
+          String(str)
+            .replace(/&/g, "&amp;")
+            .replace(/"/g, "&quot;")
+            .replace(/'/g, "&#39;")
+            .replace(/</g, "&lt;")
+            .replace(/>/g, "&gt;");
+
         const servicesItems = fetchedServices.response.resultPacket.results
           .slice(0, 4)
           .map(
@@ -205,7 +213,7 @@ export async function showSuggestions(value = "", isDefault = false, form) {
           .join("");
 
         const viewMoreItem = viewMoreUrl
-          ? `<li><a tabindex="0" href="${viewMoreUrl}" class="view-more">View more</a></li>`
+          ? `<li><a tabindex="0" href="${escapeHtmlAttr(viewMoreUrl)}" class="view-more">View more</a></li>`
           : "";
 
         dynamicSuggestionsContainer.innerHTML += `


### PR DESCRIPTION
Fix for [https://github.com/qld-gov-au/qgds-bootstrap5/security/code-scanning/14](https://github.com/qld-gov-au/qgds-bootstrap5/security/code-scanning/14)

- Patch applied to escape the `viewMoreUrl` string before embedding it inside HTML, specifically as an attribute value (href).

The functional behaviour remains the same, but it will now be more secure against XSS.
