### PR TITLE
chore(npm): use fixed npm version for CI release

### DIFF
--- a/.github/workflows/npmjsPackage.yml
+++ b/.github/workflows/npmjsPackage.yml
@@ -118,7 +118,7 @@ jobs:
 
       # Ensure npm 11.5.1 or later is installed
       - name: Update npm
-        run: npm install -g npm@latest
+        run: npm install -g "npm@11.11.0"
 
       - run: npm ci
 

--- a/.github/workflows/npmjsPackage.yml
+++ b/.github/workflows/npmjsPackage.yml
@@ -116,10 +116,12 @@ jobs:
           cache: 'npm'
           scope: '@qld-gov-au'
 
-      # Ensure npm 11.5.1 or later is installed
       - name: Update npm
-        run: npm install -g "npm@11.11.0"
-
+        run: |
+          echo "installing via incremental upgrade to use latest npm in node 22 (not required in node 24+)"
+          npm install -g npm@~11.10.0
+          npm install -g npm@latest
+          
       - run: npm ci
 
       - name: Build 🔧


### PR DESCRIPTION
The PR provides a temporary patch to resolve an NPM release workflow bug. 

Our NPM release workflow uses npm@latest, which has a failing `promise-retry` dependency. More at https://github.com/npm/cli/pull/9152

This PR will force our workflow to use npm@11.11.0. Following this manual intervention, npm@latest can then be re-applied. 