### PR TITLE
QGDS-840: Header Logo lockup has empty link

### DIFF
--- a/src/components/bs5/header/header.hbs
+++ b/src/components/bs5/header/header.hbs
@@ -6,7 +6,8 @@
             <div class="d-flex justify-content-between">
 
                 <a class="qld-header-link align-self-center"
-                    href="{{#if preHeader.globalLink.url}}{{preHeader.globalLink.url}}{{else}}https://qld.gov.au{{/if}}">
+                    href="{{#if preHeader.globalLink.url}}{{preHeader.globalLink.url}}{{else}}https://qld.gov.au{{/if}}"
+                    aria-label="{{#if preHeader.globalLink.text}}{{preHeader.globalLink.text}}{{else}}Queensland Government{{/if}}">
                     <span class="d-none d-lg-inline">{{preHeader.globalLink.text}}</span>
                     {{#if hasDeliveringForQLDLogo}}
                     {{>logo logo="coa-delivering-for-qld" className="qld-header-logo is-delivering-for-qld" fill="currentColor"}}

--- a/src/components/bs5/header/headerBrand.hbs
+++ b/src/components/bs5/header/headerBrand.hbs
@@ -1,6 +1,6 @@
 
 <div class="qld-header-brand">
-    <a class="qld-header-link d-lg-inline-flex align-middle" href="{{url}}">
+    <a class="qld-header-link d-lg-inline-flex align-middle" href="{{url}}"{{#unless logo}}{{#unless siteTitle}} aria-label="Queensland Government"{{/unless}}{{/unless}}>
         <div class="qld-header-brand-image align-self-center">
             {{#if logo}}
             <img src="{{logo.src}}" height="56" alt="{{#if logo.altText}}{{logo.altText}}{{else}}Queensland government{{/if}}" />


### PR DESCRIPTION
WCAG 2.2: Adds text attribute to the Header Logo, with a `qld.gov.au` fallback.  Uses `preHeader.globalLink.text` parameter