### PR TITLE
QGDS-792: first column of every table stretches out in print view

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8814,9 +8814,9 @@
       "license": "MIT"
     },
     "node_modules/selenium-webdriver": {
-      "version": "4.40.0",
-      "resolved": "https://registry.npmjs.org/selenium-webdriver/-/selenium-webdriver-4.40.0.tgz",
-      "integrity": "sha512-dU0QbnVKdPmoNP8OtMCazRdtU2Ux6Wl4FEpG1iwUbDeajJK1dBAywBLrC1D7YFRtogHzN96AbXBgBAJaarcysw==",
+      "version": "4.43.0",
+      "resolved": "https://registry.npmjs.org/selenium-webdriver/-/selenium-webdriver-4.43.0.tgz",
+      "integrity": "sha512-dV4zBTT37or3Z3/8uD6rS8zvd4ZxPuG4EJVlqYIbZCGZCYttZm7xb9rlFLSk4rrsQHAeDYvudl7cquo0vWpHjg==",
       "dev": true,
       "funding": [
         {
@@ -8833,7 +8833,7 @@
         "@bazel/runfiles": "^6.5.0",
         "jszip": "^3.10.1",
         "tmp": "^0.2.5",
-        "ws": "^8.18.3"
+        "ws": "^8.20.0"
       },
       "engines": {
         "node": ">= 20.0.0"
@@ -11630,9 +11630,9 @@
       "license": "ISC"
     },
     "node_modules/ws": {
-      "version": "8.18.3",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
-      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
+      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/src/css/qld-print.scss
+++ b/src/css/qld-print.scss
@@ -37,6 +37,24 @@
     transition: none !important;
   }
 
+  // The universal width: 100% above breaks table column distribution
+  // (every cell wants 100%, so the first one stretches and the rest squeeze).
+  // Restore natural sizing so columns share width based on content.
+  table,
+  thead,
+  tbody,
+  tfoot,
+  tr,
+  th,
+  td,
+  caption {
+    width: auto;
+  }
+
+  table {
+    width: 100%;
+  }
+
   *:before,
   *:after {
     color: #000 !important;


### PR DESCRIPTION
Root cause — the print stylesheet's universal rule * { width: 100%; ... } applies width: 100% to every element. For <th>/<td>, that means every cell asks for 100% of the row's width. The browser then has to pick a winner: the first cell expands to its content width, and the remaining cells get squeezed.

Fix — after the universal rule, explicitly reset all table-internal elements (thead, tbody, tfoot, tr, th, td, caption) to width: auto so columns auto-distribute by content, and restore <table> itself to width: 100% so the table still fills the page.