### PR TITLE
fix: to break long email addresses into next line

### DIFF
--- a/src/css/qld-utilities.scss
+++ b/src/css/qld-utilities.scss
@@ -44,7 +44,7 @@ $utilities: map-merge(
 
 // Utility: Style mailto links
 a[href^="mailto:"] {
-  word-wrap: break-word;
+  word-break: break-word;
   overflow-wrap: break-word;
 }
 


### PR DESCRIPTION
## Version 2.2.1 Hotfix
An email link wrap issue was found following minor release v2.2.0. This hotfix applies overflow-wrap: break-word, to improve word-break performance for long email addresses.